### PR TITLE
Feature/nav 64 enrich raptor results inside of raptor to include trips ids etc

### DIFF
--- a/src/main/java/ch/naviqore/app/dto/DtoDummyData.java
+++ b/src/main/java/ch/naviqore/app/dto/DtoDummyData.java
@@ -210,7 +210,7 @@ public class DtoDummyData {
         int footpathSpeed = 100; // meters per minute
         int footpathTravelTime = footpathDistance / footpathSpeed; // in minutes
 
-        return new Leg(from.getCoordinates(), to.getCoordinates(), from, to, LegType.WALK, departureTime,
+        return new Leg(LegType.WALK, from.getCoordinates(), to.getCoordinates(), from, to, departureTime,
                 departureTime.plusMinutes(footpathTravelTime), null);
     }
 
@@ -268,7 +268,7 @@ public class DtoDummyData {
 
         Trip trip = new Trip(to.getName(), route, stopTimes);
 
-        return new Leg(from.getCoordinates(), to.getCoordinates(), from, to, LegType.ROUTE, tripDepartureTime,
+        return new Leg(LegType.ROUTE, from.getCoordinates(), to.getCoordinates(), from, to, tripDepartureTime,
                 tripArrivalTime, trip);
     }
 

--- a/src/main/java/ch/naviqore/app/dto/DtoMapper.java
+++ b/src/main/java/ch/naviqore/app/dto/DtoMapper.java
@@ -59,31 +59,23 @@ public class DtoMapper {
     private static class LegVisitorImpl implements LegVisitor<Leg> {
         @Override
         public Leg visit(PublicTransitLeg publicTransitLeg) {
-            // TODO: Trip id in raptor has to be passed first.
-            return new Leg(
-                    // map(publicTransitLeg.getDeparture().getStop().getLocation()),
-                    // map(publicTransitLeg.getArrival().getStop().getLocation()),
-                    null, null,
-                    // map(publicTransitLeg.getDeparture().getStop()),
-                    // map(publicTransitLeg.getArrival().getStop()),
-                    null, null, LegType.ROUTE,
-                    // publicTransitLeg.getDeparture().getDepartureTime(),
-                    // publicTransitLeg.getArrival().getArrivalTime(),
-                    null, null,
-                    // map(publicTransitLeg.getTrip())
-                    null);
+            return new Leg(LegType.ROUTE, publicTransitLeg.getDeparture().getStop().getLocation(),
+                    publicTransitLeg.getArrival().getStop().getLocation(),
+                    map(publicTransitLeg.getDeparture().getStop()), map(publicTransitLeg.getArrival().getStop()),
+                    publicTransitLeg.getDeparture().getDepartureTime(), publicTransitLeg.getArrival().getArrivalTime(),
+                    map(publicTransitLeg.getTrip()));
         }
 
         @Override
         public Leg visit(Transfer transfer) {
-            return new Leg(transfer.getSourceStop().getLocation(), transfer.getTargetStop().getLocation(),
-                    map(transfer.getSourceStop()), map(transfer.getTargetStop()), LegType.WALK,
-                    transfer.getDepartureTime(), transfer.getArrivalTime(), null);
+            return new Leg(LegType.WALK, transfer.getSourceStop().getLocation(), transfer.getTargetStop().getLocation(),
+                    map(transfer.getSourceStop()), map(transfer.getTargetStop()), transfer.getDepartureTime(),
+                    transfer.getArrivalTime(), null);
         }
 
         @Override
         public Leg visit(Walk walk) {
-            return new Leg(walk.getSourceLocation(), walk.getTargetLocation(), null, null, LegType.WALK,
+            return new Leg(LegType.WALK, walk.getSourceLocation(), walk.getTargetLocation(), null, null,
                     walk.getDepartureTime(), walk.getArrivalTime(), null);
         }
     }

--- a/src/main/java/ch/naviqore/app/dto/DtoMapper.java
+++ b/src/main/java/ch/naviqore/app/dto/DtoMapper.java
@@ -53,7 +53,7 @@ public class DtoMapper {
     }
 
     public static EarliestArrival map(ch.naviqore.service.Stop stop, ch.naviqore.service.Connection connection) {
-        return new EarliestArrival(map(stop), connection.getLegs().getLast().getArrivalTime(), map(connection));
+        return new EarliestArrival(map(stop), connection.getArrivalTime(), map(connection));
     }
 
     private static class LegVisitorImpl implements LegVisitor<Leg> {

--- a/src/main/java/ch/naviqore/app/dto/DtoMapper.java
+++ b/src/main/java/ch/naviqore/app/dto/DtoMapper.java
@@ -75,7 +75,21 @@ public class DtoMapper {
 
         @Override
         public Leg visit(Walk walk) {
-            return new Leg(LegType.WALK, walk.getSourceLocation(), walk.getTargetLocation(), null, null,
+            Stop sourceStop = null;
+            Stop targetStop = null;
+
+            // set stop depending on walk type
+            if (walk.getStop().isPresent()) {
+                switch (walk.getWalkType()) {
+                    case WalkType.LAST_MILE -> sourceStop = map(walk.getStop().get());
+                    case WalkType.FIRST_MILE -> targetStop = map(walk.getStop().get());
+                    // a walk between two stations is a TransferLeg and not a Walk, therefore this case should not occur
+                    case DIRECT -> throw new IllegalStateException(
+                            "No stop should be present in a direct walk between two location.");
+                }
+            }
+
+            return new Leg(LegType.WALK, walk.getSourceLocation(), walk.getTargetLocation(), sourceStop, targetStop,
                     walk.getDepartureTime(), walk.getArrivalTime(), null);
         }
     }

--- a/src/main/java/ch/naviqore/app/dto/Leg.java
+++ b/src/main/java/ch/naviqore/app/dto/Leg.java
@@ -12,11 +12,11 @@ import java.time.LocalDateTime;
 @Getter
 public class Leg {
 
+    private final LegType type;
     private final GeoCoordinate from;
     private final GeoCoordinate to;
     private final Stop fromStop;
     private final Stop toStop;
-    private final LegType type;
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private final LocalDateTime departureTime;
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)

--- a/src/main/java/ch/naviqore/raptor/Connection.java
+++ b/src/main/java/ch/naviqore/raptor/Connection.java
@@ -75,7 +75,15 @@ public class Connection implements Comparable<Connection> {
         return getArrivalTime() - getDepartureTime();
     }
 
-    public int getNumSameStationTransfers() {
+    public List<Leg> getWalkTransfers() {
+        return legs.stream().filter(l -> l.type == LegType.WALK_TRANSFER).toList();
+    }
+
+    public List<Leg> getRouteLegs() {
+        return legs.stream().filter(l -> l.type == LegType.ROUTE).toList();
+    }
+
+    public int getNumberOfSameStationTransfers() {
         int transferCounter = 0;
         for (int i = 0; i < legs.size() - 1; i++) {
             Leg current = legs.get(i);
@@ -87,16 +95,8 @@ public class Connection implements Comparable<Connection> {
         return transferCounter;
     }
 
-    public int getNumWalkTransfers() {
-        return (int) legs.stream().filter(l -> l.type == LegType.WALK_TRANSFER).count();
-    }
-
-    public int getNumTransfers() {
-        return getNumWalkTransfers() + getNumSameStationTransfers();
-    }
-
-    public int getNumRouteLegs() {
-        return (int) legs.stream().filter(l -> l.type == LegType.ROUTE).count();
+    public int getNumberOfTotalTransfers() {
+        return getWalkTransfers().size() + getNumberOfSameStationTransfers();
     }
 
     /**

--- a/src/main/java/ch/naviqore/raptor/Connection.java
+++ b/src/main/java/ch/naviqore/raptor/Connection.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -109,8 +110,8 @@ public class Connection implements Comparable<Connection> {
     /**
      * A leg is a part of a connection that is travelled on the same route and transport mode, without a transfer.
      */
-    public record Leg(String routeId, String fromStopId, String toStopId, int departureTime, int arrivalTime,
-                      LegType type) implements Comparable<Leg> {
+    public record Leg(String routeId, @Nullable String tripId, String fromStopId, String toStopId, int departureTime,
+                      int arrivalTime, LegType type) implements Comparable<Leg> {
 
         @Override
         public int compareTo(@NotNull Connection.Leg other) {

--- a/src/main/java/ch/naviqore/raptor/Connection.java
+++ b/src/main/java/ch/naviqore/raptor/Connection.java
@@ -75,10 +75,6 @@ public class Connection implements Comparable<Connection> {
         return getArrivalTime() - getDepartureTime();
     }
 
-    public int getNumFootPathTransfers() {
-        return (int) legs.stream().filter(l -> l.type == LegType.FOOTPATH).count();
-    }
-
     public int getNumSameStationTransfers() {
         int transferCounter = 0;
         for (int i = 0; i < legs.size() - 1; i++) {
@@ -91,8 +87,12 @@ public class Connection implements Comparable<Connection> {
         return transferCounter;
     }
 
+    public int getNumWalkTransfers() {
+        return (int) legs.stream().filter(l -> l.type == LegType.WALK_TRANSFER).count();
+    }
+
     public int getNumTransfers() {
-        return getNumFootPathTransfers() + getNumSameStationTransfers();
+        return getNumWalkTransfers() + getNumSameStationTransfers();
     }
 
     public int getNumRouteLegs() {
@@ -103,7 +103,7 @@ public class Connection implements Comparable<Connection> {
      * Types of legs in a connection.
      */
     public enum LegType {
-        FOOTPATH,
+        WALK_TRANSFER,
         ROUTE
     }
 

--- a/src/main/java/ch/naviqore/raptor/Raptor.java
+++ b/src/main/java/ch/naviqore/raptor/Raptor.java
@@ -397,7 +397,7 @@ public class Raptor {
 
             } else if (leg.type == ArrivalType.TRANSFER) {
                 routeId = String.format("transfer_%s_%s", fromStopId, toStopId);
-                type = Connection.LegType.FOOTPATH;
+                type = Connection.LegType.WALK_TRANSFER;
                 // include same stop transfer time (which is subtracted before scanning routes)
                 arrivalTime += SAME_STOP_TRANSFER_TIME;
 

--- a/src/main/java/ch/naviqore/raptor/Raptor.java
+++ b/src/main/java/ch/naviqore/raptor/Raptor.java
@@ -380,7 +380,8 @@ public class Raptor {
 
         // start from destination leg and follow legs back until the initial leg is reached
         while (leg.type != ArrivalType.INITIAL) {
-            String id;
+            String routeId;
+            String tripId = null;
             assert leg.previous != null;
             String fromStopId = stops[leg.previous.stopIdx].id();
             String toStopId = stops[leg.stopIdx].id();
@@ -389,11 +390,13 @@ public class Raptor {
             int arrivalTime = leg.arrivalTime;
 
             if (leg.type == ArrivalType.ROUTE) {
-                id = routes[leg.routeOrTransferIdx].id();
+                Route route = routes[leg.routeOrTransferIdx];
+                routeId = route.id();
+                tripId = route.tripIds()[leg.tripOffset];
                 type = Connection.LegType.ROUTE;
 
             } else if (leg.type == ArrivalType.TRANSFER) {
-                id = String.format("transfer_%s_%s", fromStopId, toStopId);
+                routeId = String.format("transfer_%s_%s", fromStopId, toStopId);
                 type = Connection.LegType.FOOTPATH;
                 // include same stop transfer time (which is subtracted before scanning routes)
                 arrivalTime += SAME_STOP_TRANSFER_TIME;
@@ -402,7 +405,8 @@ public class Raptor {
                 throw new IllegalStateException("Unknown arrival type");
             }
 
-            connection.addLeg(new Connection.Leg(id, fromStopId, toStopId, departureTime, arrivalTime, type));
+            connection.addLeg(
+                    new Connection.Leg(routeId, tripId, fromStopId, toStopId, departureTime, arrivalTime, type));
             leg = leg.previous;
         }
 

--- a/src/main/java/ch/naviqore/raptor/Raptor.java
+++ b/src/main/java/ch/naviqore/raptor/Raptor.java
@@ -529,7 +529,7 @@ public class Raptor {
                 throw new IllegalArgumentException("At least one stop ID must be provided.");
             }
 
-            // loop over all stop pairs and validate departure times and if stop exists in raptor
+            // loop over all stop pairs and check if stop exists in raptor, then validate departure time
             Map<Integer, Integer> validStopIds = new HashMap<>();
             for (Map.Entry<String, Integer> entry : stops.entrySet()) {
                 String stopId = entry.getKey();
@@ -538,8 +538,9 @@ public class Raptor {
                 if (stopsToIdx.containsKey(stopId)) {
                     validateDepartureTime(time);
                     validStopIds.put(stopsToIdx.get(stopId), time);
+                } else {
+                    log.warn("Stop ID {} not found in lookup removing from query.", entry.getKey());
                 }
-                log.warn("Stop ID {} not found in lookup removing from query.", entry.getKey());
             }
 
             if (validStopIds.isEmpty()) {

--- a/src/main/java/ch/naviqore/raptor/Raptor.java
+++ b/src/main/java/ch/naviqore/raptor/Raptor.java
@@ -160,7 +160,7 @@ public class Raptor {
             // subtract same stop transfer time, as this will be added by default before scanning routes
             earliestArrivals[sourceStopIdxs[i]] = departureTimes[i] - SAME_STOP_TRANSFER_TIME;
             earliestArrivalsPerRound.getFirst()[sourceStopIdxs[i]] = new Leg(0, departureTimes[i], ArrivalType.INITIAL,
-                    NO_INDEX, sourceStopIdxs[i], null);
+                    NO_INDEX, NO_INDEX, sourceStopIdxs[i], null);
             markedStops.add(sourceStopIdxs[i]);
         }
 
@@ -249,9 +249,10 @@ public class Raptor {
                                 continue;
                             }
 
+                            // create a route leg
                             earliestArrivals[stopIdx] = stopTime.arrival();
                             earliestArrivalsThisRound[stopIdx] = new Leg(tripEntryTime, stopTime.arrival(),
-                                    ArrivalType.ROUTE, currentRouteIdx, stopIdx, enteredAtArrival);
+                                    ArrivalType.ROUTE, currentRouteIdx, tripOffset, stopIdx, enteredAtArrival);
                             // mark stop improvement for next round
                             markedStopsNext.add(stopIdx);
                             // check if this was a target stop
@@ -317,7 +318,7 @@ public class Raptor {
                                 stops[stopIdx].id());
                         earliestArrivals[transfer.targetStopIdx()] = newTargetStopArrivalTime;
                         earliestArrivalsThisRound[transfer.targetStopIdx()] = new Leg(earliestArrivals[stopIdx],
-                                newTargetStopArrivalTime, ArrivalType.TRANSFER, i, transfer.targetStopIdx(),
+                                newTargetStopArrivalTime, ArrivalType.TRANSFER, i, NO_INDEX, transfer.targetStopIdx(),
                                 earliestArrivalsThisRound[stopIdx]);
                         newStops.add(transfer.targetStopIdx());
                     }
@@ -432,7 +433,7 @@ public class Raptor {
             }
             earliestArrivals[transfer.targetStopIdx()] = newTargetStopArrivalTime;
             earliestArrivalsPerRound.getFirst()[transfer.targetStopIdx()] = new Leg(departureTime,
-                    newTargetStopArrivalTime, ArrivalType.TRANSFER, i, transfer.targetStopIdx(),
+                    newTargetStopArrivalTime, ArrivalType.TRANSFER, i, NO_INDEX, transfer.targetStopIdx(),
                     earliestArrivalsPerRound.getFirst()[sourceStopIdx]);
             markedStops.add(transfer.targetStopIdx());
         }
@@ -464,12 +465,13 @@ public class Raptor {
      * @param departureTime      the departure time of the leg in seconds after midnight.
      * @param arrivalTime        the arrival time of the leg in seconds after midnight.
      * @param type               the type of the leg, can be INITIAL, ROUTE or TRANSFER.
-     * @param routeOrTransferIdx the index of the route or of the transfer, see arrival type.
+     * @param routeOrTransferIdx the index of the route or of the transfer, see arrival type (or NO_INDEX).
+     * @param tripOffset         the trip offset on the current route (or NO_INDEX).
      * @param stopIdx            the arrival stop of the leg.
      * @param previous           the previous leg, null if it is the previous leg.
      */
-    private record Leg(int departureTime, int arrivalTime, ArrivalType type, int routeOrTransferIdx, int stopIdx,
-                       @Nullable Leg previous) {
+    private record Leg(int departureTime, int arrivalTime, ArrivalType type, int routeOrTransferIdx, int tripOffset,
+                       int stopIdx, @Nullable Leg previous) {
     }
 
     /**

--- a/src/main/java/ch/naviqore/raptor/RaptorBuilder.java
+++ b/src/main/java/ch/naviqore/raptor/RaptorBuilder.java
@@ -190,8 +190,8 @@ public class RaptorBuilder {
             // add route entry to route array
             final int numberOfStops = routeContainer.stopSequence().size();
             final int numberOfTrips = routeContainer.trips().size();
-            routeArr[routeIdx] = new Route(routeContainer.id(), routeStopCnt, numberOfStops, stopTimeCnt,
-                    numberOfTrips);
+            routeArr[routeIdx] = new Route(routeContainer.id(), routeStopCnt, numberOfStops, stopTimeCnt, numberOfTrips,
+                    routeContainer.trips().keySet().toArray(new String[0]));
 
             // add stops to route stop array
             Map<Integer, String> stopSequence = routeContainer.stopSequence();

--- a/src/main/java/ch/naviqore/raptor/Route.java
+++ b/src/main/java/ch/naviqore/raptor/Route.java
@@ -1,4 +1,5 @@
 package ch.naviqore.raptor;
 
-record Route(String id, int firstRouteStopIdx, int numberOfStops, int firstStopTimeIdx, int numberOfTrips) {
+record Route(String id, int firstRouteStopIdx, int numberOfStops, int firstStopTimeIdx, int numberOfTrips,
+             String[] tripIds) {
 }

--- a/src/main/java/ch/naviqore/service/Connection.java
+++ b/src/main/java/ch/naviqore/service/Connection.java
@@ -1,5 +1,6 @@
 package ch.naviqore.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -8,5 +9,9 @@ import java.util.List;
 public interface Connection {
 
     List<Leg> getLegs();
+
+    LocalDateTime getDepartureTime();
+
+    LocalDateTime getArrivalTime();
 
 }

--- a/src/main/java/ch/naviqore/service/Leg.java
+++ b/src/main/java/ch/naviqore/service/Leg.java
@@ -1,7 +1,5 @@
 package ch.naviqore.service;
 
-import java.time.LocalDateTime;
-
 public interface Leg {
 
     LegType getLegType();
@@ -12,7 +10,4 @@ public interface Leg {
 
     int getDuration();
 
-    LocalDateTime getDepartureTime();
-
-    LocalDateTime getArrivalTime();
 }

--- a/src/main/java/ch/naviqore/service/Walk.java
+++ b/src/main/java/ch/naviqore/service/Walk.java
@@ -2,11 +2,16 @@ package ch.naviqore.service;
 
 import ch.naviqore.utils.spatial.GeoCoordinate;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface Walk extends Leg {
 
     WalkType getWalkType();
+
+    LocalDateTime getDepartureTime();
+
+    LocalDateTime getArrivalTime();
 
     GeoCoordinate getSourceLocation();
 

--- a/src/main/java/ch/naviqore/service/impl/ConnectionImpl.java
+++ b/src/main/java/ch/naviqore/service/impl/ConnectionImpl.java
@@ -1,12 +1,12 @@
 package ch.naviqore.service.impl;
 
-import ch.naviqore.service.Connection;
-import ch.naviqore.service.Leg;
+import ch.naviqore.service.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
@@ -16,4 +16,43 @@ public class ConnectionImpl implements Connection {
 
     private final List<Leg> legs;
 
+    @Override
+    public LocalDateTime getDepartureTime() {
+        return legs.getFirst().accept(new LegVisitor<>() {
+            @Override
+            public LocalDateTime visit(PublicTransitLeg publicTransitLeg) {
+                return publicTransitLeg.getDeparture().getDepartureTime();
+            }
+
+            @Override
+            public LocalDateTime visit(Transfer transfer) {
+                return transfer.getDepartureTime();
+            }
+
+            @Override
+            public LocalDateTime visit(Walk walk) {
+                return walk.getDepartureTime();
+            }
+        });
+    }
+
+    @Override
+    public LocalDateTime getArrivalTime() {
+        return legs.getLast().accept(new LegVisitor<>() {
+            @Override
+            public LocalDateTime visit(PublicTransitLeg publicTransitLeg) {
+                return publicTransitLeg.getArrival().getArrivalTime();
+            }
+
+            @Override
+            public LocalDateTime visit(Transfer transfer) {
+                return transfer.getArrivalTime();
+            }
+
+            @Override
+            public LocalDateTime visit(Walk walk) {
+                return walk.getArrivalTime();
+            }
+        });
+    }
 }

--- a/src/main/java/ch/naviqore/service/impl/PublicTransitLegImpl.java
+++ b/src/main/java/ch/naviqore/service/impl/PublicTransitLegImpl.java
@@ -4,8 +4,6 @@ import ch.naviqore.service.*;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.time.LocalDateTime;
-
 @Getter
 @ToString(callSuper = true)
 public class PublicTransitLegImpl extends LegImpl implements PublicTransitLeg {
@@ -24,16 +22,6 @@ public class PublicTransitLegImpl extends LegImpl implements PublicTransitLeg {
     @Override
     public <T> T accept(LegVisitor<T> visitor) {
         return visitor.visit(this);
-    }
-
-    @Override
-    public LocalDateTime getDepartureTime() {
-        return departure.getDepartureTime();
-    }
-
-    @Override
-    public LocalDateTime getArrivalTime() {
-        return arrival.getArrivalTime();
     }
 
 }

--- a/src/main/java/ch/naviqore/service/impl/PublicTransitLegImpl.java
+++ b/src/main/java/ch/naviqore/service/impl/PublicTransitLegImpl.java
@@ -11,14 +11,14 @@ import java.time.LocalDateTime;
 public class PublicTransitLegImpl extends LegImpl implements PublicTransitLeg {
 
     private final Trip trip;
-    private final StopTime arrival;
     private final StopTime departure;
+    private final StopTime arrival;
 
-    PublicTransitLegImpl(int distance, int duration, Trip trip, StopTime arrival, StopTime departure) {
+    PublicTransitLegImpl(int distance, int duration, Trip trip, StopTime departure, StopTime arrival) {
         super(LegType.PUBLIC_TRANSIT, distance, duration);
         this.trip = trip;
-        this.arrival = arrival;
         this.departure = departure;
+        this.arrival = arrival;
     }
 
     @Override

--- a/src/main/java/ch/naviqore/service/impl/PublicTransitServiceImpl.java
+++ b/src/main/java/ch/naviqore/service/impl/PublicTransitServiceImpl.java
@@ -43,7 +43,6 @@ public class PublicTransitServiceImpl implements PublicTransitService {
     private static final int MIN_WALK_DURATION = 120;
     private final ServiceConfig config;
     private final GtfsSchedule schedule;
-    // private final Map<String, List<ch.naviqore.gtfs.schedule.model.Stop>> parentStops;
     private final KDTree<ch.naviqore.gtfs.schedule.model.Stop> spatialStopIndex;
     private final SearchIndex<ch.naviqore.gtfs.schedule.model.Stop> stopSearchIndex;
     private final WalkCalculator walkCalculator;
@@ -86,6 +85,7 @@ public class PublicTransitServiceImpl implements PublicTransitService {
         if (stop != null && stop.getParent().isPresent() && !stop.getParent().get().equals(stop)) {
             stop = stop.getParent().get();
         }
+
         return Optional.ofNullable(map(stop));
     }
 

--- a/src/main/java/ch/naviqore/service/impl/StopTimeImpl.java
+++ b/src/main/java/ch/naviqore/service/impl/StopTimeImpl.java
@@ -10,13 +10,14 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 @Getter
-@ToString
+@ToString(exclude = "trip")
 public class StopTimeImpl implements StopTime {
 
     private final Stop stop;
     private final LocalDateTime arrivalTime;
     private final LocalDateTime departureTime;
     @Setter(AccessLevel.PACKAGE)
-    private Trip trip;
+    // cyclical dependency, therefore avoid serialization and use in toString representation
+    private transient Trip trip;
 
 }

--- a/src/main/java/ch/naviqore/service/impl/TypeMapper.java
+++ b/src/main/java/ch/naviqore/service/impl/TypeMapper.java
@@ -95,7 +95,7 @@ final class TypeMapper {
         Stop sourceStop = map(schedule.getStops().get(leg.fromStopId()));
         Stop targetStop = map(schedule.getStops().get(leg.toStopId()));
         return switch (leg.type()) {
-            case FOOTPATH -> new TransferImpl(distance, duration, toLocalDateTime(leg.departureTime(), date),
+            case WALK_TRANSFER -> new TransferImpl(distance, duration, toLocalDateTime(leg.departureTime(), date),
                     toLocalDateTime(leg.arrivalTime(), date), sourceStop, targetStop);
             // TODO: Refactor Raptor and extract interfaces. Put Trip id on leg, then stop time can be found.
             case ROUTE -> new PublicTransitLegImpl(distance, duration, null, null, null);

--- a/src/main/java/ch/naviqore/utils/spatial/CartesianCoordinate.java
+++ b/src/main/java/ch/naviqore/utils/spatial/CartesianCoordinate.java
@@ -61,7 +61,7 @@ public class CartesianCoordinate implements Coordinate {
 
     @Override
     public String toString() {
-        return "[" + this.getClass().getSimpleName() + ": " + x + ", " + y + "]";
+        return this.getClass().getSimpleName() + "(x=" + x + ", y=" + y + ")";
     }
 
 }

--- a/src/main/java/ch/naviqore/utils/spatial/GeoCoordinate.java
+++ b/src/main/java/ch/naviqore/utils/spatial/GeoCoordinate.java
@@ -91,6 +91,6 @@ public record GeoCoordinate(double latitude, double longitude) implements Coordi
 
     @Override
     public String toString() {
-        return "[" + this.getClass().getSimpleName() + ": " + latitude + "°, " + longitude + "°]";
+        return this.getClass().getSimpleName() + "(lat=" + latitude + "°, lon=" + longitude + "°)";
     }
 }

--- a/src/test/java/ch/naviqore/Benchmark.java
+++ b/src/test/java/ch/naviqore/Benchmark.java
@@ -160,8 +160,14 @@ final class Benchmark {
                 connections.stream().mapToInt(Connection::getArrivalTime).min().orElse(NOT_AVAILABLE));
         int minDuration = connections.stream().mapToInt(Connection::getDuration).min().orElse(NOT_AVAILABLE);
         int maxDuration = connections.stream().mapToInt(Connection::getDuration).max().orElse(NOT_AVAILABLE);
-        int minTransfers = connections.stream().mapToInt(Connection::getNumTransfers).min().orElse(NOT_AVAILABLE);
-        int maxTransfers = connections.stream().mapToInt(Connection::getNumTransfers).max().orElse(NOT_AVAILABLE);
+        int minTransfers = connections.stream()
+                .mapToInt(Connection::getNumberOfTotalTransfers)
+                .min()
+                .orElse(NOT_AVAILABLE);
+        int maxTransfers = connections.stream()
+                .mapToInt(Connection::getNumberOfTotalTransfers)
+                .max()
+                .orElse(NOT_AVAILABLE);
         long beelineDistance = Math.round(
                 request.sourceStop.getCoordinate().distanceTo(request.targetStop.getCoordinate()));
         long processingTime = (endTime - startTime) / NS_TO_MS_CONVERSION_FACTOR;

--- a/src/test/java/ch/naviqore/raptor/RaptorTest.java
+++ b/src/test/java/ch/naviqore/raptor/RaptorTest.java
@@ -47,7 +47,7 @@ class RaptorTest {
             assertTrue(connection1.getDepartureTime() >= departureTime,
                     "Departure time should be greater equal than searched for departure time");
             // check that transfers make sense
-            assertEquals(1, connection1.getNumFootPathTransfers());
+            assertEquals(1, connection1.getNumWalkTransfers());
             assertEquals(1, connection1.getNumTransfers());
             assertEquals(0, connection1.getNumSameStationTransfers());
 
@@ -58,7 +58,7 @@ class RaptorTest {
             assertTrue(connection2.getDepartureTime() >= departureTime,
                     "Departure time should be greater equal than searched for departure time");
             // check that transfers make sense
-            assertEquals(0, connection2.getNumFootPathTransfers());
+            assertEquals(0, connection2.getNumWalkTransfers());
             assertEquals(2, connection2.getNumTransfers());
             assertEquals(2, connection2.getNumSameStationTransfers());
 
@@ -83,7 +83,7 @@ class RaptorTest {
             assertEquals(targetStop, connection.getToStopId());
             assertTrue(connection.getDepartureTime() >= departureTime,
                     "Departure time should be greater equal than searched for departure time");
-            assertEquals(0, connection.getNumFootPathTransfers());
+            assertEquals(0, connection.getNumWalkTransfers());
             assertEquals(0, connection.getNumTransfers());
             assertEquals(0, connection.getNumSameStationTransfers());
         }
@@ -120,7 +120,7 @@ class RaptorTest {
             assertEquals(targetStop, connection.getToStopId());
             assertTrue(connection.getDepartureTime() >= departureTime,
                     "Departure time should be greater equal than searched for departure time");
-            assertEquals(1, connection.getNumFootPathTransfers());
+            assertEquals(1, connection.getNumWalkTransfers());
             assertEquals(1, connection.getNumTransfers());
             assertEquals(0, connection.getNumSameStationTransfers());
             assertEquals(0, connection.getNumRouteLegs());

--- a/src/test/java/ch/naviqore/raptor/RaptorTest.java
+++ b/src/test/java/ch/naviqore/raptor/RaptorTest.java
@@ -47,9 +47,9 @@ class RaptorTest {
             assertTrue(connection1.getDepartureTime() >= departureTime,
                     "Departure time should be greater equal than searched for departure time");
             // check that transfers make sense
-            assertEquals(1, connection1.getNumWalkTransfers());
-            assertEquals(1, connection1.getNumTransfers());
-            assertEquals(0, connection1.getNumSameStationTransfers());
+            assertEquals(1, connection1.getWalkTransfers().size());
+            assertEquals(1, connection1.getNumberOfTotalTransfers());
+            assertEquals(0, connection1.getNumberOfSameStationTransfers());
 
             // check second connection
             Connection connection2 = connections.get(1);
@@ -58,14 +58,14 @@ class RaptorTest {
             assertTrue(connection2.getDepartureTime() >= departureTime,
                     "Departure time should be greater equal than searched for departure time");
             // check that transfers make sense
-            assertEquals(0, connection2.getNumWalkTransfers());
-            assertEquals(2, connection2.getNumTransfers());
-            assertEquals(2, connection2.getNumSameStationTransfers());
+            assertEquals(0, connection2.getWalkTransfers().size());
+            assertEquals(2, connection2.getNumberOfTotalTransfers());
+            assertEquals(2, connection2.getNumberOfSameStationTransfers());
 
             // compare two connections (make sure they are pareto optimal)
             assertTrue(connection1.getDuration() > connection2.getDuration(),
                     "First connection should be slower than second connection");
-            assertTrue(connection1.getNumRouteLegs() < connection2.getNumRouteLegs(),
+            assertTrue(connection1.getRouteLegs().size() < connection2.getRouteLegs().size(),
                     "First connection should have fewer route legs than second connection");
         }
 
@@ -83,9 +83,9 @@ class RaptorTest {
             assertEquals(targetStop, connection.getToStopId());
             assertTrue(connection.getDepartureTime() >= departureTime,
                     "Departure time should be greater equal than searched for departure time");
-            assertEquals(0, connection.getNumWalkTransfers());
-            assertEquals(0, connection.getNumTransfers());
-            assertEquals(0, connection.getNumSameStationTransfers());
+            assertEquals(0, connection.getWalkTransfers().size());
+            assertEquals(0, connection.getNumberOfTotalTransfers());
+            assertEquals(0, connection.getNumberOfSameStationTransfers());
         }
 
         @Test
@@ -120,10 +120,10 @@ class RaptorTest {
             assertEquals(targetStop, connection.getToStopId());
             assertTrue(connection.getDepartureTime() >= departureTime,
                     "Departure time should be greater equal than searched for departure time");
-            assertEquals(1, connection.getNumWalkTransfers());
-            assertEquals(1, connection.getNumTransfers());
-            assertEquals(0, connection.getNumSameStationTransfers());
-            assertEquals(0, connection.getNumRouteLegs());
+            assertEquals(1, connection.getWalkTransfers().size());
+            assertEquals(1, connection.getNumberOfTotalTransfers());
+            assertEquals(0, connection.getNumberOfSameStationTransfers());
+            assertEquals(0, connection.getRouteLegs().size());
         }
 
         @Nested

--- a/src/test/resources/ch/naviqore/app/ApplicationTest.rest
+++ b/src/test/resources/ch/naviqore/app/ApplicationTest.rest
@@ -1,4 +1,4 @@
-### Nearest stop
+### Nearest stops
 GET http://localhost:8080/schedule/stops/nearest?latitude=36&longitude=-116&maxDistance=500000
 Accept: application/json
 


### PR DESCRIPTION
Add trip information to Raptor Route and store the trip offset in the Raptor legs to be able to reconstruct the connection. Pass trip information on to the Connection of the service and finally map to connection DTO.

Further adds:
- Some documentation.
- Application of the visitor in the connection implementation of the service to get the connection arrival and departure time, while removing the redundant information on the public transit leg.
- Transient to trip on stop info to break the cyclical dependency