### PR TITLE
Feature/nav 91 create raptor cache to prevent building raptor everytime for same date queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,12 +137,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.23.1</version>
+            <version>3.0.0-beta1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.23.1</version>
+            <version>3.0.0-beta1</version>
         </dependency>
         <!-- io -->
         <dependency>

--- a/src/main/java/ch/naviqore/service/impl/PublicTransitServiceImpl.java
+++ b/src/main/java/ch/naviqore/service/impl/PublicTransitServiceImpl.java
@@ -52,8 +52,8 @@ public class PublicTransitServiceImpl implements PublicTransitService {
     private final SearchIndex<ch.naviqore.gtfs.schedule.model.Stop> stopSearchIndex;
     private final WalkCalculator walkCalculator;
     private final List<TransferGenerator.Transfer> additionalTransfers;
-    private final EvictionCache<LocalDate, Raptor> raptorCache = new EvictionCache<>(CACHE_SIZE,
-            CACHE_EVICTION_STRATEGY);
+    private final EvictionCache<Set<ch.naviqore.gtfs.schedule.model.Trip>, Raptor> raptorCache = new EvictionCache<>(
+            CACHE_SIZE, CACHE_EVICTION_STRATEGY);
 
     public PublicTransitServiceImpl(ServiceConfig config) {
         this.config = config;
@@ -280,7 +280,7 @@ public class PublicTransitServiceImpl implements PublicTransitService {
 
     private Raptor getRaptor(LocalDate date) {
         // TODO: Not always create a new raptor, use mask on stop times based on active trips
-        return raptorCache.computeIfAbsent(date,
+        return raptorCache.computeIfAbsent(new HashSet<>(schedule.getActiveTrips(date)),
                 () -> new GtfsToRaptorConverter(schedule, additionalTransfers).convert(date));
     }
 

--- a/src/main/java/ch/naviqore/utils/cache/EvictionCache.java
+++ b/src/main/java/ch/naviqore/utils/cache/EvictionCache.java
@@ -46,7 +46,7 @@ public class EvictionCache<K, V> {
      */
     public synchronized V computeIfAbsent(K key, Supplier<V> supplier) {
         if (cache.containsKey(key)) {
-            log.info("Cache hit, retrieving cached instance for key {}", key);
+            log.debug("Cache hit, retrieving cached instance for key {}", key);
             updateAccessOrder(key);
             return cache.get(key);
         }
@@ -55,7 +55,7 @@ public class EvictionCache<K, V> {
             evict();
         }
 
-        log.info("No cache hit, computing new instance for key {}", key);
+        log.debug("No cache hit, computing new instance for key {}", key);
         V value = supplier.get();
         cache.put(key, value);
         updateAccessOrder(key);
@@ -88,7 +88,7 @@ public class EvictionCache<K, V> {
     private void evict() {
         K keyToEvict = strategy == Strategy.LRU ? findLRUKey() : findMRUKey();
         if (keyToEvict != null) {
-            log.info("Removing cached key {}, last access at {}", keyToEvict, accessOrder.get(keyToEvict));
+            log.debug("Removing cached key {}, last access at {}", keyToEvict, accessOrder.get(keyToEvict));
             cache.remove(keyToEvict);
             accessOrder.remove(keyToEvict);
         }

--- a/src/main/java/ch/naviqore/utils/cache/EvictionCache.java
+++ b/src/main/java/ch/naviqore/utils/cache/EvictionCache.java
@@ -1,0 +1,107 @@
+package ch.naviqore.utils.cache;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * A generic cache class that supports LRU (Least Recently Used) and MRU (Most Recently Used) eviction strategies.
+ *
+ * @param <K> the type of keys maintained by this cache
+ * @param <V> the type of mapped values
+ */
+public class EvictionCache<K, V> {
+    private final int size;
+    private final Strategy strategy;
+    private final Map<K, V> cache;
+    private final LinkedHashMap<K, Long> accessOrder; // Tracks insertion and access order
+
+    /**
+     * Enum representing the eviction strategy.
+     */
+    public enum Strategy {
+        LRU,
+        MRU
+    }
+
+    /**
+     * Constructs a new EvictionCache with the specified size and eviction strategy.
+     *
+     * @param size     the maximum number of elements the cache can hold
+     * @param strategy the eviction strategy to use (LRU or MRU)
+     */
+    public EvictionCache(int size, Strategy strategy) {
+        if (size <= 0) {
+            throw new IllegalArgumentException("Size must be greater than 0.");
+        }
+        this.size = size;
+        this.strategy = strategy;
+        this.cache = new HashMap<>();
+        this.accessOrder = new LinkedHashMap<>();
+    }
+
+    /**
+     * If the specified key is not already associated with a value (or is mapped to {@code null}), attempts to compute
+     * its value using the given supplier and enters it into this cache.
+     *
+     * @param key      the key with which the specified value is to be associated
+     * @param supplier the supplier function to compute the value
+     * @return the current (existing or computed) value associated with the specified key
+     */
+    public synchronized V computeIfAbsent(K key, Supplier<V> supplier) {
+        if (cache.containsKey(key)) {
+            updateAccessOrder(key);
+            return cache.get(key);
+        }
+
+        if (cache.size() >= size) {
+            evict();
+        }
+
+        V value = supplier.get();
+        cache.put(key, value);
+        updateAccessOrder(key);
+
+        return value;
+    }
+
+    /**
+     * Clears the cache, removing all key-value mappings.
+     */
+    public synchronized void clear() {
+        cache.clear();
+        accessOrder.clear();
+    }
+
+    /**
+     * Checks if the specified key is present in the cache.
+     *
+     * @param key the key whose presence in this cache is to be tested
+     * @return {@code true} if this cache contains a mapping for the specified key
+     */
+    public boolean isCached(K key) {
+        return cache.containsKey(key);
+    }
+
+    private void updateAccessOrder(K key) {
+        accessOrder.put(key, System.nanoTime());
+    }
+
+    private void evict() {
+        K keyToEvict = strategy == Strategy.LRU ? findLRUKey() : findMRUKey();
+        if (keyToEvict != null) {
+            cache.remove(keyToEvict);
+            accessOrder.remove(keyToEvict);
+        }
+    }
+
+    private K findLRUKey() {
+        return accessOrder.entrySet().stream().min(Map.Entry.comparingByValue()).map(Map.Entry::getKey).orElse(null);
+    }
+
+    private K findMRUKey() {
+        return accessOrder.entrySet().stream().max(Map.Entry.comparingByValue()).map(Map.Entry::getKey).orElse(null);
+    }
+
+}

--- a/src/main/java/ch/naviqore/utils/cache/EvictionCache.java
+++ b/src/main/java/ch/naviqore/utils/cache/EvictionCache.java
@@ -21,14 +21,6 @@ public class EvictionCache<K, V> {
     private final LinkedHashMap<K, Long> accessOrder; // Tracks insertion and access order
 
     /**
-     * Enum representing the eviction strategy.
-     */
-    public enum Strategy {
-        LRU,
-        MRU
-    }
-
-    /**
      * Constructs a new EvictionCache with the specified size and eviction strategy.
      *
      * @param size     the maximum number of elements the cache can hold
@@ -108,6 +100,14 @@ public class EvictionCache<K, V> {
 
     private K findMRUKey() {
         return accessOrder.entrySet().stream().max(Map.Entry.comparingByValue()).map(Map.Entry::getKey).orElse(null);
+    }
+
+    /**
+     * Enum representing the eviction strategy.
+     */
+    public enum Strategy {
+        LRU,
+        MRU
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+# logging
+logging.level.root=${LOG_LEVEL:INFO}
 # gtfs
 gtfs.static.url=${GTFS_STATIC_URL:src/test/resources/ch/naviqore/gtfs/schedule/sample-feed-1.zip}
 # gtfs.static.url=benchmark/input/switzerland.zip

--- a/src/test/java/ch/naviqore/utils/cache/EvictionCacheTest.java
+++ b/src/test/java/ch/naviqore/utils/cache/EvictionCacheTest.java
@@ -1,0 +1,108 @@
+package ch.naviqore.utils.cache;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EvictionCacheTest {
+
+    public static final int CACHE_SIZE = 3;
+
+    @Nested
+    class LRU {
+
+        private EvictionCache<String, String> lruCache;
+
+        @BeforeEach
+        void setUp() {
+            lruCache = new EvictionCache<>(CACHE_SIZE, EvictionCache.Strategy.LRU);
+        }
+
+        @Test
+        void shouldComputeIfAbsent() {
+            assertThat(lruCache.isCached("a")).isFalse();
+            lruCache.computeIfAbsent("a", () -> "apple");
+            assertThat(lruCache.isCached("a")).isTrue();
+            assertThat(lruCache.computeIfAbsent("a", () -> "apple")).isEqualTo("apple");
+        }
+
+        @Test
+        void shouldRemoveLeastRecentlyUsed() {
+            lruCache.computeIfAbsent("a", () -> "apple");
+            lruCache.computeIfAbsent("b", () -> "banana");
+            lruCache.computeIfAbsent("c", () -> "cherry");
+
+            // access "a" again to make it recently used
+            lruCache.computeIfAbsent("a", () -> "apple");
+            // this should evict "b"
+            lruCache.computeIfAbsent("d", () -> "date");
+
+            assertThat(lruCache.isCached("b")).isFalse();
+            assertThat(lruCache.isCached("a")).isTrue();
+            assertThat(lruCache.isCached("c")).isTrue();
+            assertThat(lruCache.isCached("d")).isTrue();
+        }
+
+        @Test
+        void shouldClear() {
+            lruCache.computeIfAbsent("a", () -> "apple");
+            lruCache.computeIfAbsent("b", () -> "banana");
+            lruCache.computeIfAbsent("c", () -> "cherry");
+
+            lruCache.clear();
+
+            assertThat(lruCache.isCached("a")).isFalse();
+            assertThat(lruCache.isCached("b")).isFalse();
+            assertThat(lruCache.isCached("c")).isFalse();
+        }
+    }
+
+    @Nested
+    class MRU {
+
+        private EvictionCache<String, String> mruCache;
+
+        @BeforeEach
+        void setUp() {
+            mruCache = new EvictionCache<>(CACHE_SIZE, EvictionCache.Strategy.MRU);
+        }
+
+        @Test
+        void shouldComputeIfAbsent() {
+            assertThat(mruCache.isCached("a")).isFalse();
+            mruCache.computeIfAbsent("a", () -> "apple");
+            assertThat(mruCache.isCached("a")).isTrue();
+            assertThat(mruCache.computeIfAbsent("a", () -> "apple")).isEqualTo("apple");
+        }
+
+        @Test
+        void shouldRemoveMostRecentlyUsed() {
+            mruCache.computeIfAbsent("a", () -> "apple");
+            mruCache.computeIfAbsent("b", () -> "banana");
+            mruCache.computeIfAbsent("c", () -> "cherry");
+
+            // this should evict "c" as it is the most recently used
+            mruCache.computeIfAbsent("d", () -> "date");
+
+            assertThat(mruCache.isCached("c")).isFalse();
+            assertThat(mruCache.isCached("a")).isTrue();
+            assertThat(mruCache.isCached("b")).isTrue();
+            assertThat(mruCache.isCached("d")).isTrue();
+        }
+
+        @Test
+        void shouldClear() {
+            mruCache.computeIfAbsent("a", () -> "apple");
+            mruCache.computeIfAbsent("b", () -> "banana");
+            mruCache.computeIfAbsent("c", () -> "cherry");
+
+            mruCache.clear();
+
+            assertThat(mruCache.isCached("a")).isFalse();
+            assertThat(mruCache.isCached("b")).isFalse();
+            assertThat(mruCache.isCached("c")).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
Cache raptor instances per day using LRU strategy.

@clukas1 considering your description in the Jira ticket:

> - Store built raptors so that they can be re-used again if a second query for the same date is requested.
> - Ideally add logic, that raptor only get’s rebuilt if the service calendar type is different. I.e. if Wednesday and Thursday schedule is identical, use the same raptor instance for both.

The second point won't work, since there are special calendar date in the GTFS, e.g. Christmas 1. May, ... So we have to cache raptor instances per date not weekday.

But: I think I got a solution to mask trips inside Raptor. This will also eradicate the need for the stop validations (except departure time), since we have all stops from the GTFS in the raptor, but some stops will just have no active trips.

I can prepare everything around it, but would be nice to build this together into the mega loop of the Raptor, maybe Friday evening or at the weekend?

Unfortunately we still have some strange errors when stops are not present in the Raptor:

![Screenshot 2024-06-05 at 17 31 07](https://github.com/naviqore/public-transit-service/assets/29773509/979bfac6-6c16-4cb5-a559-8f9aa46a2997)
