### PR TITLE
Nav 95 raptor not handling two walk transfers in sequence correctly

### DIFF
--- a/src/main/java/ch/naviqore/app/service/ServiceConfigParser.java
+++ b/src/main/java/ch/naviqore/app/service/ServiceConfigParser.java
@@ -15,7 +15,7 @@ public class ServiceConfigParser {
                                @Value("${transfer.time.minimum:120}") int minimumTransferTime,
                                @Value("${transfer.defaultSameStationTransferTime:120}") int sameStationTransferTime,
                                @Value("${walking.distance.maximum:500}") int maxWalkingDistance,
-                               @Value("${walking.speed:3500}") int walkingSpeed,
+                               @Value("${walking.speed:2500}") int walkingSpeed,
                                @Value("${walking.calculator.type:BEE_LINE_DISTANCE}") String walkCalculatorTypeStr) {
         ServiceConfig.WalkCalculatorType walkCalculatorType = ServiceConfig.WalkCalculatorType.valueOf(
                 walkCalculatorTypeStr.toUpperCase());

--- a/src/main/java/ch/naviqore/raptor/Raptor.java
+++ b/src/main/java/ch/naviqore/raptor/Raptor.java
@@ -437,7 +437,14 @@ public class Raptor {
             return;
         }
         Stop sourceStop = stops[stopIdx];
-        int arrivalTime = earliestArrivals[stopIdx];
+        Leg previousLeg = earliestArrivalsPerRound.get(round)[stopIdx];
+
+        // do not relax footpath from stop that was only reached by footpath in the same round
+        if (previousLeg == null || previousLeg.type == ArrivalType.TRANSFER) {
+            return;
+        }
+
+        int arrivalTime = previousLeg.arrivalTime();
 
         for (int i = sourceStop.transferIdx(); i < sourceStop.transferIdx() + sourceStop.numberOfTransfers(); i++) {
             Transfer transfer = transfers[i];

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,5 +8,5 @@ gtfs.static.update.interval.hours=${GTFS_STATIC_UPDATE_INTERVAL:24}
 transfer.time.minimum=${TRANSFER_TIME_MINIMUM:120}
 # walking
 walking.calculator.type=${WALKING_CALCULATOR_TYPE:BEE_LINE_DISTANCE}
-walking.speed=${WALKING_SPEED:3500}
+walking.speed=${WALKING_SPEED:2500}
 walking.distance.maximum=${WALKING_DISTANCE_MAXIMUM:500}


### PR DESCRIPTION
Mini fix required because footpath relaxation was using transfer arrival time with same station transfer time subtracted in case of previous arrival by walk transfer.