### PR TITLE
Bugfix/nav 99 fix GitHub actions which are not triggering upon release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker publish
 
 on:
   release:
-    types: [created]
+    types: [ created ]
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,9 +1,8 @@
 name: Docker publish
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+\.[0-9]+\.[0-9]+(-.*)?'
+  release:
+    types: [created]
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,9 +1,8 @@
 name: Maven publish
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+\.[0-9]+\.[0-9]+(-.*)?'
+  release:
+    types: [created]
 
 jobs:
   publish:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -2,7 +2,7 @@ name: Maven publish
 
 on:
   release:
-    types: [created]
+    types: [ created ]
 
 jobs:
   publish:

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ch.naviqore</groupId>
     <artifactId>public-transit-service</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
 
     <name>Public Transit Service</name>
     <description>

--- a/src/main/java/ch/naviqore/service/impl/convert/GtfsToRaptorConverter.java
+++ b/src/main/java/ch/naviqore/service/impl/convert/GtfsToRaptorConverter.java
@@ -36,7 +36,8 @@ public class GtfsToRaptorConverter {
         this(schedule, List.of(), sameStationTransferTime);
     }
 
-    public GtfsToRaptorConverter(GtfsSchedule schedule, List<TransferGenerator.Transfer> additionalTransfers, int sameStationTransferTime) {
+    public GtfsToRaptorConverter(GtfsSchedule schedule, List<TransferGenerator.Transfer> additionalTransfers,
+                                 int sameStationTransferTime) {
         this.partitioner = new GtfsRoutePartitioner(schedule);
         this.additionalTransfers = additionalTransfers;
         this.schedule = schedule;

--- a/src/test/java/ch/naviqore/Benchmark.java
+++ b/src/test/java/ch/naviqore/Benchmark.java
@@ -97,7 +97,8 @@ final class Benchmark {
                 SAME_STATION_TRANSFER_TIME);
         additionalGeneratedTransfers.addAll(sameStationTransferGenerator.generateTransfers(schedule));
 
-        Raptor raptor = new GtfsToRaptorConverter(schedule, additionalGeneratedTransfers, SAME_STATION_TRANSFER_TIME).convert(SCHEDULE_DATE);
+        Raptor raptor = new GtfsToRaptorConverter(schedule, additionalGeneratedTransfers,
+                SAME_STATION_TRANSFER_TIME).convert(SCHEDULE_DATE);
         manageResources();
         return raptor;
     }

--- a/src/test/java/ch/naviqore/raptor/RaptorTest.java
+++ b/src/test/java/ch/naviqore/raptor/RaptorTest.java
@@ -203,8 +203,7 @@ class RaptorTest {
         void takeSlowerRouteOfOverlappingRoutesDueToEarlierDepartureTime(RaptorTestBuilder builder) {
             // Create Two Versions of the same route with different travel speeds and different departure times
             Raptor raptor = builder.withAddRoute1_AG()
-                    .withAddRoute1_AG("R1X", 15, 30, 3,
-                            RaptorTestBuilder.DEFAULT_DWELL_TIME)
+                    .withAddRoute1_AG("R1X", 15, 30, 3, RaptorTestBuilder.DEFAULT_DWELL_TIME)
                     .build();
             List<Connection> connections = raptor.routeEarliestArrival(STOP_A, STOP_G, EIGHT_AM);
 


### PR DESCRIPTION
Created a new release: https://github.com/naviqore/public-transit-service/releases/tag/v0.2.0

But the publish action was not triggered via the tag listener. Therefore the publish actions listen now directly on the release, when it is created.

After merge of this PR I would release a patch version v0.2.1 to check if publish is successful.


```
# Release Notes for v0.2.1

This patch release addresses an issue with GitHub Actions not being triggered upon release. The following changes have been made:

## Bug Fixes
- **Trigger Maven Publish**: Fixed the maven-publish.yml to trigger upon release creation. ([#61](https://github.com/naviqore/public-transit-service/pull/61))
- **Trigger Docker Publish**: Fixed the docker-publish.yml to trigger upon release creation. ([#61](https://github.com/naviqore/public-transit-service/pull/61))
```