### PR TITLE
FIX: NAV-100 - Fix edge case where two legs have same departure times…

### DIFF
--- a/src/main/java/ch/naviqore/raptor/Connection.java
+++ b/src/main/java/ch/naviqore/raptor/Connection.java
@@ -115,7 +115,16 @@ public class Connection implements Comparable<Connection> {
 
         @Override
         public int compareTo(@NotNull Connection.Leg other) {
-            return Integer.compare(this.departureTime, other.departureTime);
+            // sort legs first by departure time than by arrival time since there some legs that actually have the same
+            // departure and arrival time (really short distance local service) and therefore the following leg may
+            // have the same departure time but a later arrival time
+            int comparison = Integer.compare(this.departureTime, other.departureTime);
+            if (comparison != 0) {
+                return comparison;
+            } else {
+                return Integer.compare(this.arrivalTime, other.arrivalTime);
+            }
+
         }
 
     }


### PR DESCRIPTION
Minor fix, because there where legs with 0 s travel time
![Untitled](https://github.com/naviqore/public-transit-service/assets/27030718/6eb02c3a-1b57-44c2-9a10-263bc0e67963)
![Untitled-1](https://github.com/naviqore/public-transit-service/assets/27030718/eb37b141-d139-4ec8-9b9f-e00ea236730f)

Thus building connections by just sorting after departure time was not sufficient anymore, since consequent transfers would have identical departure times from the arrival stop.