### PR TITLE
Feature/nav 113 make raptor use unix timestamps instead of seconds of day

### DIFF
--- a/src/main/java/ch/naviqore/raptor/Connection.java
+++ b/src/main/java/ch/naviqore/raptor/Connection.java
@@ -1,5 +1,6 @@
 package ch.naviqore.raptor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -7,15 +8,15 @@ import java.util.List;
  */
 public interface Connection extends Comparable<Connection> {
 
-    int getDepartureTime();
+    LocalDateTime getDepartureTime();
 
-    int getArrivalTime();
+    LocalDateTime getArrivalTime();
 
     String getFromStopId();
 
     String getToStopId();
 
-    int getDuration();
+    int getDurationInSeconds();
 
     List<Leg> getWalkTransfers();
 

--- a/src/main/java/ch/naviqore/raptor/Leg.java
+++ b/src/main/java/ch/naviqore/raptor/Leg.java
@@ -1,5 +1,7 @@
 package ch.naviqore.raptor;
 
+import java.time.LocalDateTime;
+
 /**
  * A leg is a part of a connection that is travelled on the same route and transport mode, without a transfer.
  */
@@ -13,9 +15,9 @@ public interface Leg extends Comparable<Leg> {
 
     String getToStopId();
 
-    int getDepartureTime();
+    LocalDateTime getDepartureTime();
 
-    int getArrivalTime();
+    LocalDateTime getArrivalTime();
 
     Type getType();
 

--- a/src/main/java/ch/naviqore/raptor/impl/ConnectionImpl.java
+++ b/src/main/java/ch/naviqore/raptor/impl/ConnectionImpl.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.jetbrains.annotations.NotNull;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -23,10 +25,10 @@ class ConnectionImpl implements Connection {
         if (!current.getToStopId().equals(next.getFromStopId())) {
             throw new IllegalStateException("Legs are not connected: " + current + " -> " + next);
         }
-        if (current.getArrivalTime() < current.getDepartureTime()) {
+        if (current.getArrivalTime().isBefore(current.getDepartureTime())) {
             throw new IllegalStateException("Arrival time must be after departure time: " + current);
         }
-        if (current.getArrivalTime() > next.getDepartureTime()) {
+        if (current.getArrivalTime().isAfter(next.getDepartureTime())) {
             throw new IllegalStateException(
                     "Arrival time must be before next departure time: " + current + " -> " + next);
         }
@@ -51,16 +53,16 @@ class ConnectionImpl implements Connection {
 
     @Override
     public int compareTo(@NotNull Connection other) {
-        return Integer.compare(this.getArrivalTime(), other.getArrivalTime());
+        return getArrivalTime().compareTo(other.getArrivalTime());
     }
 
     @Override
-    public int getDepartureTime() {
+    public LocalDateTime getDepartureTime() {
         return legs.getFirst().getDepartureTime();
     }
 
     @Override
-    public int getArrivalTime() {
+    public LocalDateTime getArrivalTime() {
         return legs.getLast().getArrivalTime();
     }
 
@@ -75,8 +77,8 @@ class ConnectionImpl implements Connection {
     }
 
     @Override
-    public int getDuration() {
-        return getArrivalTime() - getDepartureTime();
+    public int getDurationInSeconds() {
+        return (int) Duration.between(getDepartureTime(), getArrivalTime()).getSeconds();
     }
 
     @Override

--- a/src/main/java/ch/naviqore/raptor/impl/LabelPostprocessor.java
+++ b/src/main/java/ch/naviqore/raptor/impl/LabelPostprocessor.java
@@ -5,6 +5,8 @@ import ch.naviqore.raptor.Leg;
 import ch.naviqore.raptor.TimeType;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -130,19 +132,19 @@ class LabelPostprocessor {
             assert currentLabel.previous() != null;
             String fromStopId;
             String toStopId;
-            int departureTime;
-            int arrivalTime;
+            int departureTimestamp;
+            int arrivalTimestamp;
             Leg.Type type;
             if (timeType == TimeType.DEPARTURE) {
                 fromStopId = stops[currentLabel.previous().stopIdx()].id();
                 toStopId = stops[currentLabel.stopIdx()].id();
-                departureTime = currentLabel.sourceTime();
-                arrivalTime = currentLabel.targetTime();
+                departureTimestamp = currentLabel.sourceTime();
+                arrivalTimestamp = currentLabel.targetTime();
             } else {
                 fromStopId = stops[currentLabel.stopIdx()].id();
                 toStopId = stops[currentLabel.previous().stopIdx()].id();
-                departureTime = currentLabel.targetTime();
-                arrivalTime = currentLabel.sourceTime();
+                departureTimestamp = currentLabel.targetTime();
+                arrivalTimestamp = currentLabel.sourceTime();
             }
 
             if (currentLabel.type() == Objective.LabelType.ROUTE) {
@@ -157,6 +159,9 @@ class LabelPostprocessor {
             } else {
                 throw new IllegalStateException("Unknown label type");
             }
+
+            LocalDateTime departureTime = LocalDateTime.ofEpochSecond(departureTimestamp, 0, ZoneOffset.UTC);
+            LocalDateTime arrivalTime = LocalDateTime.ofEpochSecond(arrivalTimestamp, 0, ZoneOffset.UTC);
 
             connection.addLeg(new LegImpl(routeId, tripId, fromStopId, toStopId, departureTime, arrivalTime, type));
         }

--- a/src/main/java/ch/naviqore/raptor/impl/LegImpl.java
+++ b/src/main/java/ch/naviqore/raptor/impl/LegImpl.java
@@ -8,6 +8,7 @@ import lombok.ToString;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
@@ -19,8 +20,8 @@ class LegImpl implements Leg {
     private final @Nullable String tripId;
     private final String fromStopId;
     private final String toStopId;
-    private final int departureTime;
-    private final int arrivalTime;
+    private final LocalDateTime departureTime;
+    private final LocalDateTime arrivalTime;
     private final Type type;
 
     @Override
@@ -28,11 +29,11 @@ class LegImpl implements Leg {
         // sort legs first by departure time than by arrival time since there some legs that actually have the same
         // departure and arrival time (really short distance local service) and therefore the following leg may
         // have the same departure time but a later arrival time
-        int comparison = Integer.compare(this.departureTime, other.getDepartureTime());
+        int comparison = getDepartureTime().compareTo(other.getDepartureTime());
         if (comparison != 0) {
             return comparison;
         } else {
-            return Integer.compare(this.arrivalTime, other.getArrivalTime());
+            return getArrivalTime().compareTo(other.getArrivalTime());
         }
 
     }
@@ -45,7 +46,7 @@ class LegImpl implements Leg {
         return Objects.equals(this.routeId, that.getRouteId()) && Objects.equals(this.tripId,
                 that.getTripId()) && Objects.equals(this.fromStopId, that.getFromStopId()) && Objects.equals(
                 this.toStopId,
-                that.getToStopId()) && this.departureTime == that.getDepartureTime() && this.arrivalTime == that.getArrivalTime() && Objects.equals(
+                that.getToStopId()) && this.getArrivalTime() == that.getArrivalTime() && this.getDepartureTime() == that.getDepartureTime() && Objects.equals(
                 this.type, that.getType());
     }
 

--- a/src/main/java/ch/naviqore/service/impl/PublicTransitServiceImpl.java
+++ b/src/main/java/ch/naviqore/service/impl/PublicTransitServiceImpl.java
@@ -1,7 +1,6 @@
 package ch.naviqore.service.impl;
 
 import ch.naviqore.gtfs.schedule.model.GtfsSchedule;
-import ch.naviqore.gtfs.schedule.type.ServiceDayTime;
 import ch.naviqore.raptor.RaptorAlgorithm;
 import ch.naviqore.service.*;
 import ch.naviqore.service.config.ConnectionQueryConfig;
@@ -203,13 +202,11 @@ public class PublicTransitServiceImpl implements PublicTransitService {
             Walk lastMile = null;
 
             if (sourceStop == null) {
-                LocalDateTime departureTime = time.toLocalDate()
-                        .atTime(new ServiceDayTime(connection.getDepartureTime()).toLocalTime());
+                LocalDateTime departureTime = connection.getDepartureTime();
                 firstMile = getFirstWalk(sourceLocation, connection.getFromStopId(), departureTime);
             }
             if (targetStop == null) {
-                LocalDateTime arrivalTime = time.toLocalDate()
-                        .atTime(new ServiceDayTime(connection.getArrivalTime()).toLocalTime());
+                LocalDateTime arrivalTime = connection.getArrivalTime();
                 lastMile = getLastWalk(targetLocation, connection.getToStopId(), arrivalTime);
             }
 
@@ -305,13 +302,9 @@ public class PublicTransitServiceImpl implements PublicTransitService {
             Walk firstMile = null;
             Walk lastMile = null;
             if (timeType == TimeType.DEPARTURE && source != null) {
-                LocalDateTime departureTime = startTime.toLocalDate()
-                        .atTime(new ServiceDayTime(connection.getDepartureTime()).toLocalTime());
-                firstMile = getFirstWalk(source, connection.getFromStopId(), departureTime);
+                firstMile = getFirstWalk(source, connection.getFromStopId(), connection.getDepartureTime());
             } else if (timeType == TimeType.ARRIVAL && source != null) {
-                LocalDateTime arrivalTime = startTime.toLocalDate()
-                        .atTime(new ServiceDayTime(connection.getDepartureTime()).toLocalTime());
-                lastMile = getLastWalk(source, connection.getFromStopId(), arrivalTime);
+                lastMile = getLastWalk(source, connection.getFromStopId(), connection.getDepartureTime());
             }
 
             Stop stop = map(schedule.getStops().get(entry.getKey()));

--- a/src/main/java/ch/naviqore/service/impl/convert/GtfsToRaptorConverter.java
+++ b/src/main/java/ch/naviqore/service/impl/convert/GtfsToRaptorConverter.java
@@ -8,6 +8,7 @@ import ch.naviqore.service.impl.transfer.TransferGenerator;
 import lombok.extern.log4j.Log4j2;
 
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -46,6 +47,8 @@ public class GtfsToRaptorConverter {
 
     public RaptorAlgorithm convert(LocalDate date) {
         List<Trip> activeTrips = schedule.getActiveTrips(date);
+        // TODO: Decide if long should be used for unix timestamps, else it will only work until January 18, 2038
+        int unixTimestampOfDay = (int) date.atStartOfDay().toEpochSecond(ZoneOffset.UTC);
         log.info("Converting {} active trips from GTFS schedule to Raptor model", activeTrips.size());
 
         for (Trip trip : activeTrips) {
@@ -73,7 +76,8 @@ public class GtfsToRaptorConverter {
             for (int i = 0; i < stopTimes.size(); i++) {
                 StopTime stopTime = stopTimes.get(i);
                 builder.addStopTime(subRoute.getId(), trip.getId(), i, stopTime.stop().getId(),
-                        stopTime.arrival().getTotalSeconds(), stopTime.departure().getTotalSeconds());
+                        unixTimestampOfDay + stopTime.arrival().getTotalSeconds(),
+                        unixTimestampOfDay + stopTime.departure().getTotalSeconds());
             }
         }
 

--- a/src/test/java/ch/naviqore/raptor/impl/RaptorTest.java
+++ b/src/test/java/ch/naviqore/raptor/impl/RaptorTest.java
@@ -6,11 +6,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -38,77 +38,122 @@ class RaptorTest {
     private static final String STOP_Q = "Q";
     private static final String STOP_S = "S";
 
-    private static final int FIVE_AM = 5 * RaptorTestBuilder.SECONDS_IN_HOUR;
-    private static final int EIGHT_AM = 8 * RaptorTestBuilder.SECONDS_IN_HOUR;
-    private static final int NINE_AM = 9 * RaptorTestBuilder.SECONDS_IN_HOUR;
+    private static final LocalDateTime START_OF_DAY = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC);
+    private static final LocalDateTime FIVE_AM = START_OF_DAY.plusHours(5);
+    private static final LocalDateTime EIGHT_AM = START_OF_DAY.plusHours(8);
+    private static final LocalDateTime NINE_AM = START_OF_DAY.plusHours(9);
 
     static class RaptorConvenienceMethods {
 
-        static Map<String, Connection> getIsoLines(RaptorAlgorithm raptor, Map<String, Integer> sourceStops) {
+        static Map<String, Connection> getIsoLines(RaptorAlgorithm raptor, Map<String, LocalDateTime> sourceStops) {
             return getIsoLines(raptor, sourceStops, new QueryConfig());
         }
 
-        static Map<String, Connection> getIsoLines(RaptorAlgorithm raptor, Map<String, Integer> sourceStops,
+        static Map<String, Connection> getIsoLines(RaptorAlgorithm raptor, Map<String, LocalDateTime> sourceStops,
                                                    QueryConfig config) {
-            return raptor.routeIsolines(createStopTimeMap(sourceStops), TimeType.DEPARTURE, config);
+            return raptor.routeIsolines(sourceStops, TimeType.DEPARTURE, config);
         }
 
         static List<Connection> routeEarliestArrival(RaptorAlgorithm raptor, String sourceStopId, String targetStopId,
-                                                     int departureTime) {
+                                                     LocalDateTime departureTime) {
             return routeEarliestArrival(raptor, createStopMap(sourceStopId, departureTime),
                     createStopMap(targetStopId, 0));
         }
 
         static List<Connection> routeEarliestArrival(RaptorAlgorithm raptor, String sourceStopId, String targetStopId,
-                                                     int departureTime, QueryConfig config) {
+                                                     LocalDateTime departureTime, QueryConfig config) {
             return routeEarliestArrival(raptor, createStopMap(sourceStopId, departureTime),
                     createStopMap(targetStopId, 0), config);
+        }
+
+        static Map<String, LocalDateTime> createStopMap(String stopId, LocalDateTime value) {
+            return Map.of(stopId, value);
         }
 
         static Map<String, Integer> createStopMap(String stopId, int value) {
             return Map.of(stopId, value);
         }
 
-        static List<Connection> routeEarliestArrival(RaptorAlgorithm raptor, Map<String, Integer> sourceStops,
+        static List<Connection> routeEarliestArrival(RaptorAlgorithm raptor, Map<String, LocalDateTime> sourceStops,
                                                      Map<String, Integer> targetStopIds) {
             return routeEarliestArrival(raptor, sourceStops, targetStopIds, new QueryConfig());
         }
 
-        static List<Connection> routeEarliestArrival(RaptorAlgorithm raptor, Map<String, Integer> sourceStops,
+        static List<Connection> routeEarliestArrival(RaptorAlgorithm raptor, Map<String, LocalDateTime> sourceStops,
                                                      Map<String, Integer> targetStopIds, QueryConfig config) {
-            return raptor.routeEarliestArrival(createStopTimeMap(sourceStops), targetStopIds, config);
+            return raptor.routeEarliestArrival(sourceStops, targetStopIds, config);
         }
 
         static List<Connection> routeLatestDeparture(RaptorAlgorithm raptor, String sourceStopId, String targetStopId,
-                                                     int arrivalTime) {
+                                                     LocalDateTime arrivalTime) {
             return routeLatestDeparture(raptor, createStopMap(sourceStopId, 0),
                     createStopMap(targetStopId, arrivalTime));
         }
 
         static List<Connection> routeLatestDeparture(RaptorAlgorithm raptor, Map<String, Integer> sourceStops,
-                                                     Map<String, Integer> targetStops) {
+                                                     Map<String, LocalDateTime> targetStops) {
             return routeLatestDeparture(raptor, sourceStops, targetStops, new QueryConfig());
         }
 
         static List<Connection> routeLatestDeparture(RaptorAlgorithm raptor, Map<String, Integer> sourceStops,
-                                                     Map<String, Integer> targetStops, QueryConfig config) {
-            return raptor.routeLatestDeparture(sourceStops, createStopTimeMap(targetStops), config);
+                                                     Map<String, LocalDateTime> targetStops, QueryConfig config) {
+            return raptor.routeLatestDeparture(sourceStops, targetStops, config);
         }
 
-        static Map<String, LocalDateTime> createStopTimeMap(Map<String, Integer> sourceStops) {
-            if (sourceStops == null) {
-                return null;
+    }
+
+    static class Helpers {
+        private static void assertEarliestArrivalConnection(Connection connection, String sourceStop, String targetStop,
+                                                            LocalDateTime requestedDepartureTime,
+                                                            int numSameStopTransfers, int numWalkTransfers,
+                                                            int numTrips) {
+            assertEquals(sourceStop, connection.getFromStopId());
+            assertEquals(targetStop, connection.getToStopId());
+
+            assertFalse(connection.getDepartureTime().isBefore(requestedDepartureTime),
+                    "Departure time should be greater equal than searched for departure time");
+
+            assertEquals(numSameStopTransfers, connection.getNumberOfSameStopTransfers(),
+                    "Number of same stop transfers should match");
+            assertEquals(numWalkTransfers, connection.getWalkTransfers().size(),
+                    "Number of walk transfers should match");
+            assertEquals(numSameStopTransfers + numWalkTransfers, connection.getNumberOfTotalTransfers(),
+                    "Number of transfers should match");
+
+            assertEquals(numTrips, connection.getRouteLegs().size(), "Number of trips should match");
+        }
+
+        private static void assertLatestDepartureConnection(Connection connection, String sourceStop, String targetStop,
+                                                            LocalDateTime requestedArrivalTime,
+                                                            int numSameStopTransfers, int numWalkTransfers,
+                                                            int numTrips) {
+            assertEquals(sourceStop, connection.getFromStopId());
+            assertEquals(targetStop, connection.getToStopId());
+
+            assertFalse(connection.getArrivalTime().isAfter(requestedArrivalTime),
+                    "Arrival time should be smaller equal than searched for arrival time");
+
+            assertEquals(numSameStopTransfers, connection.getNumberOfSameStopTransfers(),
+                    "Number of same station transfers should match");
+            assertEquals(numWalkTransfers, connection.getWalkTransfers().size(),
+                    "Number of walk transfers should match");
+            assertEquals(numSameStopTransfers + numWalkTransfers, connection.getNumberOfTotalTransfers(),
+                    "Number of transfers should match");
+
+            assertEquals(numTrips, connection.getRouteLegs().size(), "Number of trips should match");
+        }
+
+        private static void checkIfConnectionsAreParetoOptimal(List<Connection> connections) {
+            Connection previousConnection = connections.getFirst();
+            for (int i = 1; i < connections.size(); i++) {
+                Connection currentConnection = connections.get(i);
+                assertTrue(previousConnection.getDurationInSeconds() > currentConnection.getDurationInSeconds(),
+                        "Previous connection should be slower than current connection");
+                assertTrue(previousConnection.getRouteLegs().size() < currentConnection.getRouteLegs().size(),
+                        "Previous connection should have fewer route legs than current connection");
+                previousConnection = currentConnection;
             }
-            return sourceStops.entrySet()
-                    .stream()
-                    .map(entry -> Map.entry(entry.getKey(), convertUnixTimestampToLocalDateTime(entry.getValue())))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }
-
-        static LocalDateTime convertUnixTimestampToLocalDateTime(int unixTimestamp) {
-            return LocalDateTime.ofEpochSecond(unixTimestamp, 0, ZoneOffset.UTC);
-        }
-
     }
 
     @Nested
@@ -133,8 +178,8 @@ class RaptorTest {
 
             // check if 2 connections were found
             assertEquals(2, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_Q, EIGHT_AM, 0, 1, 2);
-            Helpers.assertConnection(connections.get(1), STOP_A, STOP_Q, EIGHT_AM, 2, 0, 3);
+            Helpers.assertEarliestArrivalConnection(connections.getFirst(), STOP_A, STOP_Q, EIGHT_AM, 0, 1, 2);
+            Helpers.assertEarliestArrivalConnection(connections.get(1), STOP_A, STOP_Q, EIGHT_AM, 2, 0, 3);
             Helpers.checkIfConnectionsAreParetoOptimal(connections);
         }
 
@@ -145,7 +190,7 @@ class RaptorTest {
             List<Connection> connections = RaptorConvenienceMethods.routeEarliestArrival(raptor, STOP_A, STOP_B,
                     EIGHT_AM);
             assertEquals(1, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_B, EIGHT_AM, 0, 0, 1);
+            Helpers.assertEarliestArrivalConnection(connections.getFirst(), STOP_A, STOP_B, EIGHT_AM, 0, 0, 1);
         }
 
         @Test
@@ -158,9 +203,9 @@ class RaptorTest {
             assertEquals(2, connections.size());
 
             // First Connection Should have no transfers but ride the entire loop (slow)
-            Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_H, EIGHT_AM, 0, 0, 1);
+            Helpers.assertEarliestArrivalConnection(connections.getFirst(), STOP_A, STOP_H, EIGHT_AM, 0, 0, 1);
             // Second Connection Should Change at Stop B and take the earlier trip of the same route there (faster)
-            Helpers.assertConnection(connections.get(1), STOP_A, STOP_H, EIGHT_AM, 1, 0, 2);
+            Helpers.assertEarliestArrivalConnection(connections.get(1), STOP_A, STOP_H, EIGHT_AM, 1, 0, 2);
 
             Helpers.checkIfConnectionsAreParetoOptimal(connections);
         }
@@ -169,21 +214,21 @@ class RaptorTest {
         void routeFromTwoSourceStopsWithSameDepartureTime(RaptorTestBuilder builder) {
             RaptorAlgorithm raptor = builder.buildWithDefaults();
 
-            Map<String, Integer> sourceStops = Map.of(STOP_A, EIGHT_AM, STOP_B, EIGHT_AM);
+            Map<String, LocalDateTime> sourceStops = Map.of(STOP_A, EIGHT_AM, STOP_B, EIGHT_AM);
             Map<String, Integer> targetStops = Map.of(STOP_H, 0);
 
             // fastest and only connection should be B -> H
             List<Connection> connections = RaptorConvenienceMethods.routeEarliestArrival(raptor, sourceStops,
                     targetStops);
             assertEquals(1, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_B, STOP_H, EIGHT_AM, 0, 0, 1);
+            Helpers.assertEarliestArrivalConnection(connections.getFirst(), STOP_B, STOP_H, EIGHT_AM, 0, 0, 1);
         }
 
         @Test
         void routeFromTwoSourceStopsWithLaterDepartureTimeOnCloserStop(RaptorTestBuilder builder) {
             RaptorAlgorithm raptor = builder.buildWithDefaults();
 
-            Map<String, Integer> sourceStops = Map.of(STOP_A, EIGHT_AM, STOP_B, NINE_AM);
+            Map<String, LocalDateTime> sourceStops = Map.of(STOP_A, EIGHT_AM, STOP_B, NINE_AM);
             Map<String, Integer> targetStops = Map.of(STOP_H, 0);
 
             // B -> H has no transfers but later arrival time (due to departure time one hour later)
@@ -191,9 +236,9 @@ class RaptorTest {
             List<Connection> connections = RaptorConvenienceMethods.routeEarliestArrival(raptor, sourceStops,
                     targetStops);
             assertEquals(2, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_B, STOP_H, NINE_AM, 0, 0, 1);
-            Helpers.assertConnection(connections.get(1), STOP_A, STOP_H, EIGHT_AM, 1, 0, 2);
-            assertTrue(connections.getFirst().getArrivalTime() > connections.get(1).getArrivalTime(),
+            Helpers.assertEarliestArrivalConnection(connections.getFirst(), STOP_B, STOP_H, NINE_AM, 0, 0, 1);
+            Helpers.assertEarliestArrivalConnection(connections.get(1), STOP_A, STOP_H, EIGHT_AM, 1, 0, 2);
+            assertTrue(connections.getFirst().getArrivalTime().isAfter(connections.get(1).getArrivalTime()),
                     "Connection from A should arrive earlier than connection from B");
         }
 
@@ -201,21 +246,21 @@ class RaptorTest {
         void routeFromStopToTwoTargetStopsNoWalkTimeToTarget(RaptorTestBuilder builder) {
             RaptorAlgorithm raptor = builder.buildWithDefaults();
 
-            Map<String, Integer> sourceStops = Map.of(STOP_A, EIGHT_AM);
+            Map<String, LocalDateTime> sourceStops = Map.of(STOP_A, EIGHT_AM);
             Map<String, Integer> targetStops = Map.of(STOP_F, 0, STOP_S, 0);
 
             // fastest and only connection should be A -> F
             List<Connection> connections = RaptorConvenienceMethods.routeEarliestArrival(raptor, sourceStops,
                     targetStops);
             assertEquals(1, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_F, EIGHT_AM, 0, 0, 1);
+            Helpers.assertEarliestArrivalConnection(connections.getFirst(), STOP_A, STOP_F, EIGHT_AM, 0, 0, 1);
         }
 
         @Test
         void routeFromStopToTwoTargetStopsWithWalkTimeToTarget(RaptorTestBuilder builder) {
             RaptorAlgorithm raptor = builder.buildWithDefaults();
 
-            Map<String, Integer> sourceStops = Map.of(STOP_A, EIGHT_AM);
+            Map<String, LocalDateTime> sourceStops = Map.of(STOP_A, EIGHT_AM);
             // Add one-hour walk time to target from stop F and no extra walk time from stop S
             Map<String, Integer> targetStops = Map.of(STOP_F, RaptorTestBuilder.SECONDS_IN_HOUR, STOP_S, 0);
 
@@ -224,8 +269,8 @@ class RaptorTest {
             List<Connection> connections = RaptorConvenienceMethods.routeEarliestArrival(raptor, sourceStops,
                     targetStops);
             assertEquals(2, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_F, EIGHT_AM, 0, 0, 1);
-            Helpers.assertConnection(connections.get(1), STOP_A, STOP_S, EIGHT_AM, 1, 0, 2);
+            Helpers.assertEarliestArrivalConnection(connections.getFirst(), STOP_A, STOP_F, EIGHT_AM, 0, 0, 1);
+            Helpers.assertEarliestArrivalConnection(connections.get(1), STOP_A, STOP_S, EIGHT_AM, 1, 0, 2);
 
             // Note since the required walk time to target is not added as a leg, the solutions will not be pareto
             // optimal without additional post-processing.
@@ -254,7 +299,7 @@ class RaptorTest {
             List<Connection> connections = RaptorConvenienceMethods.routeEarliestArrival(raptor, STOP_N, STOP_D,
                     EIGHT_AM);
             assertEquals(1, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_N, STOP_D, EIGHT_AM, 0, 1, 0);
+            Helpers.assertEarliestArrivalConnection(connections.getFirst(), STOP_N, STOP_D, EIGHT_AM, 0, 1, 0);
         }
 
         @Test
@@ -270,12 +315,12 @@ class RaptorTest {
             // Both Routes leave at 8:00 at Stop A, but R1 arrives at G at 8:35 whereas R1X arrives at G at 8:23
             // R1X should be taken
             assertEquals(1, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_G, EIGHT_AM, 0, 0, 1);
+            Helpers.assertEarliestArrivalConnection(connections.getFirst(), STOP_A, STOP_G, EIGHT_AM, 0, 0, 1);
             // check departure at 8:00
             Connection connection = connections.getFirst();
             assertEquals(EIGHT_AM, connection.getDepartureTime());
             // check arrival time at 8:23
-            assertEquals(EIGHT_AM + 23 * 60, connection.getArrivalTime());
+            assertEquals(EIGHT_AM.plusMinutes(23), connection.getArrivalTime());
             // check that R1X(-F for forward) route was used
             assertEquals("R1X-F", connection.getRouteLegs().getFirst().getRouteId());
         }
@@ -292,48 +337,14 @@ class RaptorTest {
             // Route R1 leaves at 8:00 at Stop A and arrives at G at 8:35 whereas R1X leaves at 8:15 from Stop A and
             // arrives at G at 8:38. R1 should be used.
             assertEquals(1, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_G, EIGHT_AM, 0, 0, 1);
+            Helpers.assertEarliestArrivalConnection(connections.getFirst(), STOP_A, STOP_G, EIGHT_AM, 0, 0, 1);
             // check departure at 8:00
             Connection connection = connections.getFirst();
             assertEquals(EIGHT_AM, connection.getDepartureTime());
             // check arrival time at 8:35
-            assertEquals(EIGHT_AM + 35 * 60, connection.getArrivalTime());
+            assertEquals(EIGHT_AM.plusMinutes(35), connection.getArrivalTime());
             // check that R1(-F for forward) route was used
             assertEquals("R1-F", connection.getRouteLegs().getFirst().getRouteId());
-        }
-
-        private static class Helpers {
-
-            private static void assertConnection(Connection connection, String sourceStop, String targetStop,
-                                                 int departureTime, int numSameStopTransfers, int numWalkTransfers,
-                                                 int numTrips) {
-                assertEquals(sourceStop, connection.getFromStopId());
-                assertEquals(targetStop, connection.getToStopId());
-                assertTrue(connection.getDepartureTime() >= departureTime,
-                        "Departure time should be greater equal than searched for departure time");
-
-                assertEquals(numSameStopTransfers, connection.getNumberOfSameStopTransfers(),
-                        "Number of same stop transfers should match");
-                assertEquals(numWalkTransfers, connection.getWalkTransfers().size(),
-                        "Number of walk transfers should match");
-                assertEquals(numSameStopTransfers + numWalkTransfers, connection.getNumberOfTotalTransfers(),
-                        "Number of transfers should match");
-
-                assertEquals(numTrips, connection.getRouteLegs().size(), "Number of trips should match");
-            }
-
-            private static void checkIfConnectionsAreParetoOptimal(List<Connection> connections) {
-                Connection previousConnection = connections.getFirst();
-                for (int i = 1; i < connections.size(); i++) {
-                    Connection currentConnection = connections.get(i);
-                    assertTrue(previousConnection.getDuration() > currentConnection.getDuration(),
-                            "Previous connection should be slower than current connection");
-                    assertTrue(previousConnection.getRouteLegs().size() < currentConnection.getRouteLegs().size(),
-                            "Previous connection should have fewer route legs than current connection");
-                    previousConnection = currentConnection;
-                }
-            }
-
         }
 
     }
@@ -360,9 +371,9 @@ class RaptorTest {
 
             // check if 2 connections were found
             assertEquals(2, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_Q, NINE_AM, 0, 1, 2);
-            Helpers.assertConnection(connections.get(1), STOP_A, STOP_Q, NINE_AM, 2, 0, 3);
-            EarliestArrival.Helpers.checkIfConnectionsAreParetoOptimal(connections);
+            Helpers.assertLatestDepartureConnection(connections.getFirst(), STOP_A, STOP_Q, NINE_AM, 0, 1, 2);
+            Helpers.assertLatestDepartureConnection(connections.get(1), STOP_A, STOP_Q, NINE_AM, 2, 0, 3);
+            Helpers.checkIfConnectionsAreParetoOptimal(connections);
         }
 
         @Test
@@ -372,7 +383,7 @@ class RaptorTest {
             List<Connection> connections = RaptorConvenienceMethods.routeLatestDeparture(raptor, STOP_A, STOP_B,
                     NINE_AM);
             assertEquals(1, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_B, NINE_AM, 0, 0, 1);
+            Helpers.assertLatestDepartureConnection(connections.getFirst(), STOP_A, STOP_B, NINE_AM, 0, 0, 1);
         }
 
         @Test
@@ -385,11 +396,11 @@ class RaptorTest {
             assertEquals(2, connections.size());
 
             // First Connection Should have no transfers but ride the entire loop (slow)
-            Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_H, NINE_AM, 0, 0, 1);
+            Helpers.assertLatestDepartureConnection(connections.getFirst(), STOP_A, STOP_H, NINE_AM, 0, 0, 1);
             // Second Connection Should Change at Stop B and take the earlier trip of the same route there (faster)
-            Helpers.assertConnection(connections.get(1), STOP_A, STOP_H, NINE_AM, 1, 0, 2);
+            Helpers.assertLatestDepartureConnection(connections.get(1), STOP_A, STOP_H, NINE_AM, 1, 0, 2);
 
-            EarliestArrival.Helpers.checkIfConnectionsAreParetoOptimal(connections);
+            Helpers.checkIfConnectionsAreParetoOptimal(connections);
         }
 
         @Test
@@ -397,13 +408,13 @@ class RaptorTest {
             RaptorAlgorithm raptor = builder.buildWithDefaults();
 
             Map<String, Integer> sourceStops = Map.of(STOP_A, 0, STOP_B, 0);
-            Map<String, Integer> targetStops = Map.of(STOP_H, NINE_AM);
+            Map<String, LocalDateTime> targetStops = Map.of(STOP_H, NINE_AM);
 
             // fastest and only connection should be B -> H
             List<Connection> connections = RaptorConvenienceMethods.routeLatestDeparture(raptor, sourceStops,
                     targetStops);
             assertEquals(1, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_B, STOP_H, NINE_AM, 0, 0, 1);
+            Helpers.assertLatestDepartureConnection(connections.getFirst(), STOP_B, STOP_H, NINE_AM, 0, 0, 1);
         }
 
         @Test
@@ -411,15 +422,15 @@ class RaptorTest {
             RaptorAlgorithm raptor = builder.buildWithDefaults();
 
             Map<String, Integer> sourceStops = Map.of(STOP_A, 0, STOP_B, RaptorTestBuilder.SECONDS_IN_HOUR);
-            Map<String, Integer> targetStops = Map.of(STOP_H, NINE_AM);
+            Map<String, LocalDateTime> targetStops = Map.of(STOP_H, NINE_AM);
 
             // B -> H has no transfers but (theoretical) worse departure time (due to extra one-hour walk time)
             // A -> H has one transfer but (theoretical) better departure time (no additional walk time
             List<Connection> connections = RaptorConvenienceMethods.routeLatestDeparture(raptor, sourceStops,
                     targetStops);
             assertEquals(2, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_B, STOP_H, NINE_AM, 0, 0, 1);
-            Helpers.assertConnection(connections.get(1), STOP_A, STOP_H, NINE_AM, 1, 0, 2);
+            Helpers.assertLatestDepartureConnection(connections.getFirst(), STOP_B, STOP_H, NINE_AM, 0, 0, 1);
+            Helpers.assertLatestDepartureConnection(connections.get(1), STOP_A, STOP_H, NINE_AM, 1, 0, 2);
         }
 
         @Test
@@ -427,13 +438,13 @@ class RaptorTest {
             RaptorAlgorithm raptor = builder.buildWithDefaults();
 
             Map<String, Integer> sourceStops = Map.of(STOP_A, 0);
-            Map<String, Integer> targetStops = Map.of(STOP_F, NINE_AM, STOP_S, NINE_AM);
+            Map<String, LocalDateTime> targetStops = Map.of(STOP_F, NINE_AM, STOP_S, NINE_AM);
 
             // fastest and only connection should be A -> F
             List<Connection> connections = RaptorConvenienceMethods.routeLatestDeparture(raptor, sourceStops,
                     targetStops);
             assertEquals(1, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_F, NINE_AM, 0, 0, 1);
+            Helpers.assertLatestDepartureConnection(connections.getFirst(), STOP_A, STOP_F, NINE_AM, 0, 0, 1);
         }
 
         @Test
@@ -442,15 +453,15 @@ class RaptorTest {
 
             Map<String, Integer> sourceStops = Map.of(STOP_A, 0);
             // Add one-hour walk time to target from stop F and no extra walk time from stop S
-            Map<String, Integer> targetStops = Map.of(STOP_F, EIGHT_AM, STOP_S, NINE_AM);
+            Map<String, LocalDateTime> targetStops = Map.of(STOP_F, EIGHT_AM, STOP_S, NINE_AM);
 
             // since F is closer to A than S, the fastest connection should be A -> F, but because of the hour
             // earlier arrival time, the connection A -> S should be faster (no additional walk time)
             List<Connection> connections = RaptorConvenienceMethods.routeLatestDeparture(raptor, sourceStops,
                     targetStops);
             assertEquals(2, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_F, EIGHT_AM, 0, 0, 1);
-            Helpers.assertConnection(connections.get(1), STOP_A, STOP_S, NINE_AM, 1, 0, 2);
+            Helpers.assertLatestDepartureConnection(connections.getFirst(), STOP_A, STOP_F, EIGHT_AM, 0, 0, 1);
+            Helpers.assertLatestDepartureConnection(connections.get(1), STOP_A, STOP_S, NINE_AM, 1, 0, 2);
         }
 
         @Test
@@ -476,7 +487,7 @@ class RaptorTest {
             List<Connection> connections = RaptorConvenienceMethods.routeLatestDeparture(raptor, STOP_N, STOP_D,
                     NINE_AM);
             assertEquals(1, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_N, STOP_D, NINE_AM, 0, 1, 0);
+            Helpers.assertLatestDepartureConnection(connections.getFirst(), STOP_N, STOP_D, NINE_AM, 0, 1, 0);
         }
 
         @Test
@@ -489,16 +500,16 @@ class RaptorTest {
 
             // Both Routes arrive at 8:35 at Stop G, but R1 leaves A at 8:00 whereas R1X leaves at A at 8:12
             // R1X should be taken
-            int arrivalTime = EIGHT_AM + 35 * 60;
+            LocalDateTime arrivalTime = EIGHT_AM.plusMinutes(35);
             List<Connection> connections = RaptorConvenienceMethods.routeLatestDeparture(raptor, STOP_A, STOP_G,
                     arrivalTime);
 
             assertEquals(1, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_G, arrivalTime, 0, 0, 1);
+            Helpers.assertLatestDepartureConnection(connections.getFirst(), STOP_A, STOP_G, arrivalTime, 0, 0, 1);
             // check departure at 8:12
             Connection connection = connections.getFirst();
-            assertEquals(EIGHT_AM + 12 * 60, connection.getDepartureTime());
-            // check arrival time at 8:23
+            assertEquals(EIGHT_AM.plusMinutes(12), connection.getDepartureTime());
+            // check arrival time at 8:35
             assertEquals(arrivalTime, connection.getArrivalTime());
             // check that R1X(-F for forward) route was used
             assertEquals("R1X-F", connection.getRouteLegs().getFirst().getRouteId());
@@ -515,9 +526,9 @@ class RaptorTest {
 
             // Route R1 leaves at 8:00 at Stop A and arrives at G at 8:35 whereas R1X leaves at 7:45 from Stop A and
             // arrives at G at 8:08. R1 should be used.
-            int arrivalTime = EIGHT_AM + 35 * 60;
+            LocalDateTime arrivalTime = EIGHT_AM.plusMinutes(35);
             assertEquals(1, connections.size());
-            Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_G, arrivalTime, 0, 0, 1);
+            Helpers.assertLatestDepartureConnection(connections.getFirst(), STOP_A, STOP_G, arrivalTime, 0, 0, 1);
             // check departure at 8:00
             Connection connection = connections.getFirst();
             assertEquals(EIGHT_AM, connection.getDepartureTime());
@@ -525,27 +536,6 @@ class RaptorTest {
             assertEquals(arrivalTime, connection.getArrivalTime());
             // check that R1(-F for forward) route was used
             assertEquals("R1-F", connection.getRouteLegs().getFirst().getRouteId());
-        }
-
-        private static class Helpers {
-
-            private static void assertConnection(Connection connection, String sourceStop, String targetStop,
-                                                 int arrivalTime, int numSameStopTransfers, int numWalkTransfers,
-                                                 int numTrips) {
-                assertEquals(sourceStop, connection.getFromStopId());
-                assertEquals(targetStop, connection.getToStopId());
-                assertTrue(connection.getArrivalTime() <= arrivalTime,
-                        "Arrival time should be smaller equal than searched for arrival time");
-
-                assertEquals(numSameStopTransfers, connection.getNumberOfSameStopTransfers(),
-                        "Number of same station transfers should match");
-                assertEquals(numWalkTransfers, connection.getWalkTransfers().size(),
-                        "Number of walk transfers should match");
-                assertEquals(numSameStopTransfers + numWalkTransfers, connection.getNumberOfTotalTransfers(),
-                        "Number of transfers should match");
-
-                assertEquals(numTrips, connection.getRouteLegs().size(), "Number of trips should match");
-            }
         }
     }
 
@@ -580,9 +570,9 @@ class RaptorTest {
                     FIVE_AM);
 
             assertEquals(1, connections.size());
-            assertEquals(FIVE_AM + 19 * 60, connections.getFirst().getDepartureTime());
 
-            assertNotEquals(FIVE_AM + 24 * 60, connections.getFirst().getLegs().get(1).getDepartureTime());
+            assertEquals(FIVE_AM.plusMinutes(19), connections.getFirst().getDepartureTime());
+            assertNotEquals(FIVE_AM.plusMinutes(24), connections.getFirst().getLegs().get(1).getDepartureTime());
         }
 
         @Test
@@ -598,8 +588,8 @@ class RaptorTest {
                     FIVE_AM);
 
             assertEquals(1, connections.size());
-            assertEquals(FIVE_AM + 19 * 60, connections.getFirst().getDepartureTime());
-            assertEquals(FIVE_AM + 24 * 60, connections.getFirst().getLegs().get(1).getDepartureTime());
+            assertEquals(FIVE_AM.plusMinutes(19), connections.getFirst().getDepartureTime());
+            assertEquals(FIVE_AM.plusMinutes(24), connections.getFirst().getLegs().get(1).getDepartureTime());
         }
 
         @Test
@@ -615,9 +605,8 @@ class RaptorTest {
                     FIVE_AM);
 
             assertEquals(1, connections.size());
-            assertEquals(FIVE_AM + 17 * 60, connections.getFirst().getDepartureTime());
-
-            assertEquals(FIVE_AM + 24 * 60, connections.getFirst().getLegs().get(1).getDepartureTime());
+            assertEquals(FIVE_AM.plusMinutes(17), connections.getFirst().getDepartureTime());
+            assertEquals(FIVE_AM.plusMinutes(24), connections.getFirst().getLegs().get(1).getDepartureTime());
         }
 
     }
@@ -651,9 +640,9 @@ class RaptorTest {
 
             // check if 2 connections were found
             assertEquals(2, connections.size());
-            EarliestArrival.Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_Q, EIGHT_AM, 0, 1, 2);
-            EarliestArrival.Helpers.assertConnection(connections.get(1), STOP_A, STOP_Q, EIGHT_AM, 2, 0, 3);
-            EarliestArrival.Helpers.checkIfConnectionsAreParetoOptimal(connections);
+            Helpers.assertEarliestArrivalConnection(connections.getFirst(), STOP_A, STOP_Q, EIGHT_AM, 0, 1, 2);
+            Helpers.assertEarliestArrivalConnection(connections.get(1), STOP_A, STOP_Q, EIGHT_AM, 2, 0, 3);
+            Helpers.checkIfConnectionsAreParetoOptimal(connections);
         }
 
         @Test
@@ -667,7 +656,7 @@ class RaptorTest {
             List<Connection> connections = RaptorConvenienceMethods.routeEarliestArrival(raptor, STOP_A, STOP_Q,
                     EIGHT_AM, queryConfig);
             assertEquals(1, connections.size());
-            EarliestArrival.Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_Q, EIGHT_AM, 2, 0, 3);
+            Helpers.assertEarliestArrivalConnection(connections.getFirst(), STOP_A, STOP_Q, EIGHT_AM, 2, 0, 3);
         }
 
         @Test
@@ -685,7 +674,7 @@ class RaptorTest {
             List<Connection> connections = RaptorConvenienceMethods.routeEarliestArrival(raptor, STOP_A, STOP_Q,
                     EIGHT_AM, queryConfig);
             assertEquals(1, connections.size());
-            EarliestArrival.Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_Q, EIGHT_AM, 0, 1, 2);
+            Helpers.assertEarliestArrivalConnection(connections.getFirst(), STOP_A, STOP_Q, EIGHT_AM, 0, 1, 2);
         }
 
         @Test
@@ -701,7 +690,7 @@ class RaptorTest {
             List<Connection> connections = RaptorConvenienceMethods.routeEarliestArrival(raptor, STOP_A, STOP_Q,
                     EIGHT_AM, queryConfig);
             assertEquals(1, connections.size());
-            EarliestArrival.Helpers.assertConnection(connections.getFirst(), STOP_A, STOP_Q, EIGHT_AM, 2, 0, 3);
+            Helpers.assertEarliestArrivalConnection(connections.getFirst(), STOP_A, STOP_Q, EIGHT_AM, 2, 0, 3);
         }
 
         @Test
@@ -720,8 +709,8 @@ class RaptorTest {
                     FIVE_AM, queryConfig);
 
             assertEquals(1, connections.size());
-            assertEquals(FIVE_AM + 19 * 60, connections.getFirst().getDepartureTime());
-            assertEquals(FIVE_AM + 39 * 60, connections.getFirst().getLegs().get(1).getDepartureTime());
+            assertEquals(FIVE_AM.plusMinutes(19), connections.getFirst().getDepartureTime());
+            assertEquals(FIVE_AM.plusMinutes(39), connections.getFirst().getLegs().get(1).getDepartureTime());
         }
 
         @Test
@@ -739,8 +728,8 @@ class RaptorTest {
                     FIVE_AM, queryConfig);
 
             assertEquals(1, connections.size());
-            assertEquals(FIVE_AM + 19 * 60, connections.getFirst().getDepartureTime());
-            assertEquals(FIVE_AM + 54 * 60, connections.getFirst().getLegs().get(1).getDepartureTime());
+            assertEquals(FIVE_AM.plusMinutes(19), connections.getFirst().getDepartureTime());
+            assertEquals(FIVE_AM.plusMinutes(54), connections.getFirst().getLegs().get(1).getDepartureTime());
         }
 
         @Test
@@ -754,13 +743,13 @@ class RaptorTest {
 
             assertEquals(2, connections.size());
             Connection firstConnection = connections.getFirst();
-            EarliestArrival.Helpers.assertConnection(firstConnection, STOP_A, STOP_Q, EIGHT_AM, 0, 1, 2);
+            Helpers.assertEarliestArrivalConnection(firstConnection, STOP_A, STOP_Q, EIGHT_AM, 0, 1, 2);
 
             // The walk transfer from D to N takes 60 minutes and the route from N to Q leaves every 75 minutes.
             Leg firstLeg = firstConnection.getRouteLegs().getFirst();
             Leg secondLeg = firstConnection.getRouteLegs().getLast();
-            int timeDiff = secondLeg.getDepartureTime() - firstLeg.getArrivalTime();
-            assertTrue(timeDiff >= 75 * 60, "Time between trips should be at least 75 minutes");
+            int timeDiff = (int) Duration.between(firstLeg.getArrivalTime(), secondLeg.getDepartureTime()).toMinutes();
+            assertTrue(timeDiff >= 75, "Time between trips should be at least 75 minutes");
         }
 
     }
@@ -814,12 +803,9 @@ class RaptorTest {
         void createIsoLinesFromTwoNotConnectedSourceStops(RaptorTestBuilder builder) {
             RaptorAlgorithm raptor = builder.withAddRoute1_AG().withAddRoute3_MQ().build();
 
-            Map<String, Integer> departureTimeHours = Map.of(STOP_A, 8, STOP_M, 16);
-
             List<String> reachableStopsFromStopA = List.of(STOP_B, STOP_C, STOP_D, STOP_E, STOP_F, STOP_G);
-            Map<String, Integer> sourceStops = Map.of(STOP_A,
-                    departureTimeHours.get(STOP_A) * RaptorTestBuilder.SECONDS_IN_HOUR, STOP_M,
-                    departureTimeHours.get(STOP_M) * RaptorTestBuilder.SECONDS_IN_HOUR);
+            Map<String, LocalDateTime> sourceStops = Map.of(STOP_A, START_OF_DAY.plusHours(8), STOP_M,
+                    START_OF_DAY.plusHours(16));
             List<String> reachableStopsFromStopM = List.of(STOP_K, STOP_N, STOP_O, STOP_P, STOP_Q);
 
             Map<String, Connection> isoLines = RaptorConvenienceMethods.getIsoLines(raptor, sourceStops);
@@ -832,15 +818,14 @@ class RaptorTest {
             for (Map.Entry<String, List<String>> entry : sourceTargets.entrySet()) {
                 String sourceStop = entry.getKey();
                 List<String> reachableStops = entry.getValue();
-                int departureTimeHour = departureTimeHours.get(sourceStop);
-                int departureTime = departureTimeHour * RaptorTestBuilder.SECONDS_IN_HOUR;
+                LocalDateTime requestedDepartureTime = sourceStops.get(sourceStop);
                 for (String stop : reachableStops) {
                     assertTrue(isoLines.containsKey(stop), "Stop " + stop + " should be reachable from " + sourceStop);
                     Connection connection = isoLines.get(stop);
-                    assertTrue(connection.getDepartureTime() >= departureTime,
+                    assertFalse(connection.getDepartureTime().isBefore(requestedDepartureTime),
                             String.format("Connection should have departure time equal or after %d:00",
-                                    departureTimeHour));
-                    assertTrue(connection.getArrivalTime() < Integer.MAX_VALUE,
+                                    requestedDepartureTime.getHour()));
+                    assertTrue(connection.getArrivalTime().toEpochSecond(ZoneOffset.UTC) < Integer.MAX_VALUE,
                             "Connection should have arrival time before infinity");
                     assertEquals(connection.getFromStopId(), sourceStop, "From stop should be " + sourceStop);
                     assertEquals(connection.getToStopId(), stop, "To stop should be " + stop);
@@ -853,12 +838,12 @@ class RaptorTest {
                 assertEquals(expectedIsoLines, isoLines.size());
                 assertFalse(isoLines.containsKey(RaptorTest.STOP_A), "Source stop should not be in iso lines");
                 for (Map.Entry<String, Connection> entry : isoLines.entrySet()) {
-                    assertTrue(RaptorTest.EIGHT_AM <= entry.getValue().getDepartureTime(),
+                    int arrivalTimeStamp = (int) entry.getValue().getArrivalTime().toEpochSecond(ZoneOffset.UTC);
+                    assertFalse(entry.getValue().getDepartureTime().isBefore(EIGHT_AM),
                             "Departure time should be greater than or equal to departure time");
-                    assertTrue(RaptorTest.EIGHT_AM < entry.getValue().getArrivalTime(),
+                    assertFalse(entry.getValue().getArrivalTime().isBefore(EIGHT_AM),
                             "Arrival time should be greater than or equal to departure time");
-                    assertTrue(entry.getValue().getArrivalTime() < INFINITY,
-                            "Arrival time should be less than INFINITY");
+                    assertTrue(arrivalTimeStamp < INFINITY, "Arrival time should be less than INFINITY");
                     assertEquals(RaptorTest.STOP_A, entry.getValue().getFromStopId(),
                             "From stop should be source stop");
                     assertEquals(entry.getKey(), entry.getValue().getToStopId(), "To stop should be key of map entry");
@@ -897,7 +882,7 @@ class RaptorTest {
 
         @Test
         void notThrowErrorForValidAndNonExistingSourceStop() {
-            Map<String, Integer> sourceStops = Map.of(STOP_A, EIGHT_AM, "NonExistentStop", EIGHT_AM);
+            Map<String, LocalDateTime> sourceStops = Map.of(STOP_A, EIGHT_AM, "NonExistentStop", EIGHT_AM);
             Map<String, Integer> targetStops = Map.of(STOP_H, 0);
 
             assertDoesNotThrow(() -> RaptorConvenienceMethods.routeEarliestArrival(raptor, sourceStops, targetStops),
@@ -906,7 +891,7 @@ class RaptorTest {
 
         @Test
         void notThrowErrorForValidAndNonExistingTargetStop() {
-            Map<String, Integer> sourceStops = Map.of(STOP_H, EIGHT_AM);
+            Map<String, LocalDateTime> sourceStops = Map.of(STOP_H, EIGHT_AM);
             Map<String, Integer> targetStops = Map.of(STOP_A, 0, "NonExistentStop", 0);
 
             assertDoesNotThrow(() -> RaptorConvenienceMethods.routeEarliestArrival(raptor, sourceStops, targetStops),
@@ -915,7 +900,7 @@ class RaptorTest {
 
         @Test
         void throwErrorForInvalidWalkToTargetTimeFromOneOfManyTargetStops() {
-            Map<String, Integer> sourceStops = Map.of(STOP_H, EIGHT_AM);
+            Map<String, LocalDateTime> sourceStops = Map.of(STOP_H, EIGHT_AM);
             Map<String, Integer> targetStops = Map.of(STOP_A, 0, STOP_B, -1);
 
             assertThrows(IllegalArgumentException.class,
@@ -925,7 +910,7 @@ class RaptorTest {
 
         @Test
         void throwErrorNullSourceStops() {
-            Map<String, Integer> sourceStops = null;
+            Map<String, LocalDateTime> sourceStops = null;
             Map<String, Integer> targetStops = Map.of(STOP_H, 0);
 
             assertThrows(IllegalArgumentException.class,
@@ -935,7 +920,7 @@ class RaptorTest {
 
         @Test
         void throwErrorNullTargetStops() {
-            Map<String, Integer> sourceStops = Map.of(STOP_A, 0);
+            Map<String, LocalDateTime> sourceStops = Map.of(STOP_A, START_OF_DAY);
             Map<String, Integer> targetStops = null;
 
             assertThrows(IllegalArgumentException.class,
@@ -945,7 +930,7 @@ class RaptorTest {
 
         @Test
         void throwErrorEmptyMapSourceStops() {
-            Map<String, Integer> sourceStops = Map.of();
+            Map<String, LocalDateTime> sourceStops = Map.of();
             Map<String, Integer> targetStops = Map.of(STOP_H, 0);
 
             assertThrows(IllegalArgumentException.class,
@@ -955,7 +940,7 @@ class RaptorTest {
 
         @Test
         void throwErrorEmptyMapTargetStops() {
-            Map<String, Integer> sourceStops = Map.of(STOP_A, 0);
+            Map<String, LocalDateTime> sourceStops = Map.of(STOP_A, START_OF_DAY);
             Map<String, Integer> targetStops = Map.of();
 
             assertThrows(IllegalArgumentException.class,

--- a/src/test/java/ch/naviqore/raptor/impl/RaptorTest.java
+++ b/src/test/java/ch/naviqore/raptor/impl/RaptorTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -100,9 +101,12 @@ class RaptorTest {
             }
             return sourceStops.entrySet()
                     .stream()
-                    .map(entry -> Map.entry(entry.getKey(),
-                            LocalDateTime.of(2021, 1, 1, 0, 0).plusSeconds(entry.getValue())))
+                    .map(entry -> Map.entry(entry.getKey(), convertUnixTimestampToLocalDateTime(entry.getValue())))
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+
+        static LocalDateTime convertUnixTimestampToLocalDateTime(int unixTimestamp) {
+            return LocalDateTime.ofEpochSecond(unixTimestamp, 0, ZoneOffset.UTC);
         }
 
     }

--- a/src/test/java/ch/naviqore/raptor/impl/RaptorTestBuilder.java
+++ b/src/test/java/ch/naviqore/raptor/impl/RaptorTestBuilder.java
@@ -3,6 +3,9 @@ package ch.naviqore.raptor.impl;
 import ch.naviqore.raptor.RaptorAlgorithm;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -79,8 +82,8 @@ public class RaptorTestBuilder {
 
             // add trips
             int tripCount = 0;
-            int time = dayStart * SECONDS_IN_HOUR + route.firstDepartureOffset * 60;
-            while (time < dayEnd * SECONDS_IN_HOUR) {
+            int timestamp = dayStart * SECONDS_IN_HOUR + route.firstDepartureOffset * 60;
+            while (timestamp < dayEnd * SECONDS_IN_HOUR) {
 
                 // add trips
                 String tripIdF = String.format("%s-F-%s", route.id, tripCount);
@@ -89,23 +92,23 @@ public class RaptorTestBuilder {
                 tripCount++;
 
                 // add stop times
-                int departureTime = time;
+                int departureTimestamp = timestamp;
                 // first stop of trip has no arrival time
-                int arrivalTime = departureTime;
+                int arrivalTimestamp = departureTimestamp;
                 for (int i = 0; i < route.stops.size(); i++) {
                     if (i + 1 == route.stops.size()) {
                         // last stop of trip has no departure time
-                        departureTime = arrivalTime;
+                        departureTimestamp = arrivalTimestamp;
                     }
-                    builder.addStopTime(routeIdF, tripIdF, i, route.stops.get(i), arrivalTime, departureTime);
-                    builder.addStopTime(routeIdR, tripIdR, i, route.stops.get(route.stops.size() - 1 - i), arrivalTime,
-                            departureTime);
+                    builder.addStopTime(routeIdF, tripIdF, i, route.stops.get(i), arrivalTimestamp, departureTimestamp);
+                    builder.addStopTime(routeIdR, tripIdR, i, route.stops.get(route.stops.size() - 1 - i),
+                            arrivalTimestamp, departureTimestamp);
 
-                    arrivalTime = departureTime + route.travelTimeBetweenStops * 60;
-                    departureTime = arrivalTime + route.dwellTimeAtSTop * 60;
+                    arrivalTimestamp = departureTimestamp + route.travelTimeBetweenStops * 60;
+                    departureTimestamp = arrivalTimestamp + route.dwellTimeAtSTop * 60;
                 }
 
-                time += route.headWayTime * 60;
+                timestamp += route.headWayTime * 60;
             }
         }
 


### PR DESCRIPTION
Implemented logic that raptor can work with unix timestamps instead of gtfs service day seconds. I think this is essential when we start working with mutli day logic. At the moment all timestamps are returned as int, however this means that all dates after 2038 will be faulty. We could convert to long. But I think this is not needed at the given moment.