### PR TITLE
REFACTOR: NAV-114 - Use only one logging framework and configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.1</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>ch.naviqore</groupId>
@@ -135,14 +135,9 @@
         </dependency>
         <!-- logging -->
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>3.0.0-beta1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>3.0.0-beta1</version>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.6</version>
         </dependency>
         <!-- io -->
         <dependency>

--- a/src/main/java/ch/naviqore/app/controller/ScheduleController.java
+++ b/src/main/java/ch/naviqore/app/controller/ScheduleController.java
@@ -4,7 +4,7 @@ import ch.naviqore.app.dto.*;
 import ch.naviqore.service.ScheduleInformationService;
 import ch.naviqore.service.exception.StopNotFoundException;
 import ch.naviqore.utils.spatial.GeoCoordinate;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -17,7 +17,7 @@ import static ch.naviqore.app.dto.DtoMapper.map;
 
 @RestController
 @RequestMapping("/schedule")
-@Log4j2
+@Slf4j
 public class ScheduleController {
 
     private final ScheduleInformationService service;

--- a/src/main/java/ch/naviqore/app/service/PublicTransitSpringService.java
+++ b/src/main/java/ch/naviqore/app/service/PublicTransitSpringService.java
@@ -11,7 +11,7 @@ import ch.naviqore.service.exception.TripNotActiveException;
 import ch.naviqore.service.exception.TripNotFoundException;
 import ch.naviqore.service.repo.GtfsScheduleRepository;
 import ch.naviqore.utils.spatial.GeoCoordinate;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @Service
-@Log4j2
+@Slf4j
 public class PublicTransitSpringService implements PublicTransitService {
 
     private final ServiceConfig config;

--- a/src/main/java/ch/naviqore/gtfs/schedule/GtfsScheduleParser.java
+++ b/src/main/java/ch/naviqore/gtfs/schedule/GtfsScheduleParser.java
@@ -5,7 +5,7 @@ import ch.naviqore.gtfs.schedule.type.ExceptionType;
 import ch.naviqore.gtfs.schedule.type.RouteType;
 import ch.naviqore.gtfs.schedule.type.ServiceDayTime;
 import ch.naviqore.gtfs.schedule.type.TransferType;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.csv.CSVRecord;
 
 import java.time.DayOfWeek;
@@ -21,7 +21,7 @@ import java.util.function.Consumer;
  *
  * @author munterfi
  */
-@Log4j2
+@Slf4j
 class GtfsScheduleParser {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");

--- a/src/main/java/ch/naviqore/gtfs/schedule/GtfsScheduleReader.java
+++ b/src/main/java/ch/naviqore/gtfs/schedule/GtfsScheduleReader.java
@@ -3,7 +3,7 @@ package ch.naviqore.gtfs.schedule;
 import ch.naviqore.gtfs.schedule.model.GtfsSchedule;
 import ch.naviqore.gtfs.schedule.model.GtfsScheduleBuilder;
 import lombok.NoArgsConstructor;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -30,7 +30,7 @@ import java.util.zip.ZipFile;
  * @author munterfi
  */
 @NoArgsConstructor
-@Log4j2
+@Slf4j
 public class GtfsScheduleReader {
 
     private static final String ZIP_FILE_EXTENSION = ".zip";

--- a/src/main/java/ch/naviqore/gtfs/schedule/model/GtfsScheduleBuilder.java
+++ b/src/main/java/ch/naviqore/gtfs/schedule/model/GtfsScheduleBuilder.java
@@ -8,7 +8,7 @@ import ch.naviqore.utils.cache.ValueObjectCache;
 import ch.naviqore.utils.spatial.GeoCoordinate;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.DayOfWeek;
@@ -25,7 +25,7 @@ import java.util.*;
  * @author munterfi
  */
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
-@Log4j2
+@Slf4j
 public class GtfsScheduleBuilder {
 
     private final ValueObjectCache<LocalDate> localDateCache = new ValueObjectCache<>();

--- a/src/main/java/ch/naviqore/raptor/router/FootpathRelaxer.java
+++ b/src/main/java/ch/naviqore/raptor/router/FootpathRelaxer.java
@@ -1,7 +1,7 @@
 package ch.naviqore.raptor.router;
 
 import ch.naviqore.raptor.TimeType;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -9,7 +9,7 @@ import java.util.Set;
 
 import static ch.naviqore.raptor.router.StopLabelsAndTimes.NO_INDEX;
 
-@Log4j2
+@Slf4j
 class FootpathRelaxer {
 
     private final Transfer[] transfers;

--- a/src/main/java/ch/naviqore/raptor/router/Query.java
+++ b/src/main/java/ch/naviqore/raptor/router/Query.java
@@ -2,7 +2,7 @@ package ch.naviqore.raptor.router;
 
 import ch.naviqore.raptor.QueryConfig;
 import ch.naviqore.raptor.TimeType;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -15,7 +15,7 @@ import static ch.naviqore.raptor.router.StopLabelsAndTimes.INFINITY;
  * The query represents a request to the raptor router and coordinates the routing logic. Each request needs a new query
  * instance.
  */
-@Log4j2
+@Slf4j
 class Query {
 
     private final int[] sourceStopIndices;

--- a/src/main/java/ch/naviqore/raptor/router/RaptorRouter.java
+++ b/src/main/java/ch/naviqore/raptor/router/RaptorRouter.java
@@ -6,7 +6,7 @@ import ch.naviqore.raptor.RaptorAlgorithm;
 import ch.naviqore.raptor.TimeType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 /**
  * Raptor algorithm implementation
  */
-@Log4j2
+@Slf4j
 class RaptorRouter implements RaptorAlgorithm, RaptorData {
 
     @Getter

--- a/src/main/java/ch/naviqore/raptor/router/RaptorRouterBuilder.java
+++ b/src/main/java/ch/naviqore/raptor/router/RaptorRouterBuilder.java
@@ -1,7 +1,7 @@
 package ch.naviqore.raptor.router;
 
 import ch.naviqore.raptor.RaptorAlgorithm;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -23,7 +23,7 @@ import static ch.naviqore.raptor.router.StopLabelsAndTimes.NO_INDEX;
  *
  * @author munterfi
  */
-@Log4j2
+@Slf4j
 public class RaptorRouterBuilder {
 
     private final int defaultSameStopTransferTime;

--- a/src/main/java/ch/naviqore/raptor/router/RouteBuilder.java
+++ b/src/main/java/ch/naviqore/raptor/router/RouteBuilder.java
@@ -1,6 +1,6 @@
 package ch.naviqore.raptor.router;
 
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -15,7 +15,7 @@ import java.util.*;
  *     <li>In the final route container all trips are sorted according to their departure time.</li>
  * </ul>
  */
-@Log4j2
+@Slf4j
 class RouteBuilder {
 
     private final String routeId;

--- a/src/main/java/ch/naviqore/raptor/router/RouteScanner.java
+++ b/src/main/java/ch/naviqore/raptor/router/RouteScanner.java
@@ -1,7 +1,7 @@
 package ch.naviqore.raptor.router;
 
 import ch.naviqore.raptor.TimeType;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashSet;
@@ -12,7 +12,7 @@ import static ch.naviqore.raptor.router.StopLabelsAndTimes.INFINITY;
 /**
  * Scans routes, which are passing marked stops, for each round.
  */
-@Log4j2
+@Slf4j
 class RouteScanner {
 
     private final Stop[] stops;

--- a/src/main/java/ch/naviqore/service/impl/PublicTransitServiceImpl.java
+++ b/src/main/java/ch/naviqore/service/impl/PublicTransitServiceImpl.java
@@ -17,7 +17,7 @@ import ch.naviqore.utils.cache.EvictionCache;
 import ch.naviqore.utils.search.SearchIndex;
 import ch.naviqore.utils.spatial.GeoCoordinate;
 import ch.naviqore.utils.spatial.index.KDTree;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 import static ch.naviqore.service.impl.TypeMapper.createWalk;
 import static ch.naviqore.service.impl.TypeMapper.map;
 
-@Log4j2
+@Slf4j
 public class PublicTransitServiceImpl implements PublicTransitService {
 
     private final ServiceConfig config;

--- a/src/main/java/ch/naviqore/service/impl/PublicTransitServiceInitializer.java
+++ b/src/main/java/ch/naviqore/service/impl/PublicTransitServiceInitializer.java
@@ -16,13 +16,13 @@ import ch.naviqore.utils.spatial.index.KDTreeBuilder;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
 
 @RequiredArgsConstructor
 @Getter(AccessLevel.PACKAGE)
-@Log4j2
+@Slf4j
 public class PublicTransitServiceInitializer {
 
     private final ServiceConfig config;

--- a/src/main/java/ch/naviqore/service/impl/convert/GtfsRoutePartitioner.java
+++ b/src/main/java/ch/naviqore/service/impl/convert/GtfsRoutePartitioner.java
@@ -4,7 +4,7 @@ import ch.naviqore.gtfs.schedule.model.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
  *
  * @author munterfi
  */
-@Log4j2
+@Slf4j
 public class GtfsRoutePartitioner {
 
     private final Map<Route, Map<String, SubRoute>> subRoutes = new HashMap<>();

--- a/src/main/java/ch/naviqore/service/impl/convert/GtfsToRaptorConverter.java
+++ b/src/main/java/ch/naviqore/service/impl/convert/GtfsToRaptorConverter.java
@@ -5,7 +5,7 @@ import ch.naviqore.gtfs.schedule.type.TransferType;
 import ch.naviqore.raptor.RaptorAlgorithm;
 import ch.naviqore.raptor.router.RaptorRouterBuilder;
 import ch.naviqore.service.impl.transfer.TransferGenerator;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDate;
 import java.util.HashSet;
@@ -22,7 +22,7 @@ import java.util.Set;
  *
  * @author munterfi
  */
-@Log4j2
+@Slf4j
 public class GtfsToRaptorConverter {
 
     private final Set<GtfsRoutePartitioner.SubRoute> addedSubRoutes = new HashSet<>();

--- a/src/main/java/ch/naviqore/service/impl/transfer/SameStopTransferGenerator.java
+++ b/src/main/java/ch/naviqore/service/impl/transfer/SameStopTransferGenerator.java
@@ -2,13 +2,13 @@ package ch.naviqore.service.impl.transfer;
 
 import ch.naviqore.gtfs.schedule.model.GtfsSchedule;
 import ch.naviqore.gtfs.schedule.model.Stop;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-@Log4j2
+@Slf4j
 public class SameStopTransferGenerator implements TransferGenerator {
 
     private final int minimumTransferTime;

--- a/src/main/java/ch/naviqore/service/impl/transfer/WalkTransferGenerator.java
+++ b/src/main/java/ch/naviqore/service/impl/transfer/WalkTransferGenerator.java
@@ -4,7 +4,7 @@ import ch.naviqore.gtfs.schedule.model.GtfsSchedule;
 import ch.naviqore.gtfs.schedule.model.Stop;
 import ch.naviqore.service.walk.WalkCalculator;
 import ch.naviqore.utils.spatial.index.KDTree;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,7 +14,7 @@ import java.util.Map;
  * Implements a transfer generator that creates minimum time transfers between stops where the {@link GtfsSchedule} does
  * not provide a transfer for and the distance is within walking distance.
  */
-@Log4j2
+@Slf4j
 public class WalkTransferGenerator implements TransferGenerator {
 
     private final WalkCalculator walkCalculator;

--- a/src/main/java/ch/naviqore/utils/cache/EvictionCache.java
+++ b/src/main/java/ch/naviqore/utils/cache/EvictionCache.java
@@ -1,7 +1,7 @@
 package ch.naviqore.utils.cache;
 
 import lombok.Getter;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -16,7 +16,7 @@ import java.util.function.Supplier;
  * @param <K> the type of keys maintained by this cache
  * @param <V> the type of mapped values
  */
-@Log4j2
+@Slf4j
 public class EvictionCache<K, V> {
     @Getter
     private final int size;

--- a/src/main/java/ch/naviqore/utils/network/FileDownloader.java
+++ b/src/main/java/ch/naviqore/utils/network/FileDownloader.java
@@ -1,6 +1,6 @@
 package ch.naviqore.utils.network;
 
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.net.URI;
@@ -14,7 +14,7 @@ import java.nio.file.Path;
  * Downloading files from a specified URL. Ensures that the directory exists before downloading and provides an option
  * to overwrite existing files.
  */
-@Log4j2
+@Slf4j
 public final class FileDownloader {
 
     private final HttpClient httpClient;

--- a/src/main/java/ch/naviqore/utils/search/SearchIndex.java
+++ b/src/main/java/ch/naviqore/utils/search/SearchIndex.java
@@ -2,7 +2,7 @@ package ch.naviqore.utils.search;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 import java.util.Set;
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
  * @param <T> the type of objects to be indexed.
  */
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
-@Log4j2
+@Slf4j
 public class SearchIndex<T> {
 
     private final Trie<Entry<T>> suffixTrie;

--- a/src/main/java/ch/naviqore/utils/search/SearchIndexBuilder.java
+++ b/src/main/java/ch/naviqore/utils/search/SearchIndexBuilder.java
@@ -1,13 +1,13 @@
 package ch.naviqore.utils.search;
 
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Builder class for creating a SearchIndex with key-value pairs.
  *
  * @param <T> the type of objects to be indexed.
  */
-@Log4j2
+@Slf4j
 public class SearchIndexBuilder<T> {
 
     private final CompressedTrie<SearchIndex.Entry<T>> suffixTrie = new CompressedTrie<>();

--- a/src/main/java/ch/naviqore/utils/spatial/index/KDTreeBuilder.java
+++ b/src/main/java/ch/naviqore/utils/spatial/index/KDTreeBuilder.java
@@ -4,7 +4,7 @@ import ch.naviqore.utils.spatial.Coordinate;
 import ch.naviqore.utils.spatial.Location;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -13,7 +13,7 @@ import java.util.List;
 import static ch.naviqore.utils.spatial.index.KDTree.getAxis;
 
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
-@Log4j2
+@Slf4j
 public class KDTreeBuilder<T extends Location<?>> {
 
     private ArrayList<T> locations = new ArrayList<>();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,8 +9,8 @@ logging.level.root=${LOG_LEVEL:INFO}
 # URL or file path to a static GTFS feed. The service will initially fetch the GTFS from this URL. If the provided
 # value is a file path, the GTFS is loaded from the file and the update interval is ignored. Examples:
 # - gtfs.static.uri=benchmark/input/switzerland.zip
-gtfs.static.uri=https://opentransportdata.swiss/en/dataset/timetable-2024-gtfs2020/permalink
-# gtfs.static.uri=${GTFS_STATIC_URL:src/test/resources/ch/naviqore/gtfs/schedule/sample-feed-1.zip}
+# - gtfs.static.uri=https://opentransportdata.swiss/en/dataset/timetable-2024-gtfs2020/permalink
+gtfs.static.uri=${GTFS_STATIC_URL:src/test/resources/ch/naviqore/gtfs/schedule/sample-feed-1.zip}
 # Cron expression for updating the static GTFS feed from the provided URL. Public transit agencies update their static
 # GTFS data regularly. Set this interval to match the agency's publish schedule. Default is to update the schedule
 # daily at 4 AM.

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,6 +1,0 @@
-rootLogger.level=INFO
-rootLogger.appenderRef.stdout.ref=STDOUT
-appender.stdout.type=Console
-appender.stdout.name=STDOUT
-appender.stdout.layout.type=PatternLayout
-appender.stdout.layout.pattern=[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n

--- a/src/test/java/ch/naviqore/Benchmark.java
+++ b/src/test/java/ch/naviqore/Benchmark.java
@@ -19,7 +19,7 @@ import ch.naviqore.utils.spatial.index.KDTree;
 import ch.naviqore.utils.spatial.index.KDTreeBuilder;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -43,7 +43,7 @@ import java.util.*;
  * @author munterfi
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-@Log4j2
+@Slf4j
 final class Benchmark {
 
     // dataset

--- a/src/test/java/ch/naviqore/BenchmarkData.java
+++ b/src/test/java/ch/naviqore/BenchmarkData.java
@@ -5,7 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -14,7 +14,7 @@ import java.nio.file.Path;
  * Benchmark data provider
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-@Log4j2
+@Slf4j
 public final class BenchmarkData {
 
     private static final Path DATA_DIRECTORY = Path.of("benchmark/input");

--- a/src/test/resources/log4j2-test.properties
+++ b/src/test/resources/log4j2-test.properties
@@ -1,6 +1,0 @@
-rootLogger.level=DEBUG
-rootLogger.appenderRef.stdout.ref=STDOUT
-appender.stdout.type=Console
-appender.stdout.name=STDOUT
-appender.stdout.layout.type=PatternLayout
-appender.stdout.layout.pattern=[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%highlight(%-5level)] %d{yyyy-MM-dd HH:mm:ss} [%t] %c{0} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
- Remove direct dependency on Log4J2 and use facade Slf4J instead.
- Use logback instead of log4j2, since it  is the Springboot default logging framework.
- Highlight level for better readability.