### PR TITLE
Bugfix/nav 119 fix combine labels if source stop transfer is against route trip direction

### DIFF
--- a/src/main/java/ch/naviqore/raptor/router/LabelPostprocessor.java
+++ b/src/main/java/ch/naviqore/raptor/router/LabelPostprocessor.java
@@ -255,6 +255,11 @@ class LabelPostprocessor {
             return;
         }
 
+        // when walking goes against the trip direction, combining is not possible
+        if (fromStart ? stopTime.arrival() < routeLabel.targetTime() : stopTime.departure() > routeLabel.sourceTime()) {
+            return;
+        }
+
         boolean isDeparture = timeType == TimeType.DEPARTURE;
         int timeDirection = isDeparture ? 1 : -1;
         int routeTime = fromStart ? (isDeparture ? stopTime.arrival() : stopTime.departure()) : (isDeparture ? stopTime.departure() : stopTime.arrival());
@@ -288,6 +293,7 @@ class LabelPostprocessor {
     private @Nullable StopTime getTripStopTimeForStopInTrip(int stopIdx, int routeIdx, int tripOffset) {
         int firstStopTimeIdx = routes[routeIdx].firstStopTimeIdx();
         int numberOfStops = routes[routeIdx].numberOfStops();
+
         int stopOffset = -1;
         for (int i = 0; i < numberOfStops; i++) {
             if (routeStops[routes[routeIdx].firstRouteStopIdx() + i].stopIndex() == stopIdx) {
@@ -295,9 +301,11 @@ class LabelPostprocessor {
                 break;
             }
         }
+
         if (stopOffset == -1) {
             return null;
         }
+
         return stopTimes[firstStopTimeIdx + tripOffset * numberOfStops + stopOffset];
     }
 

--- a/src/main/java/ch/naviqore/raptor/router/LabelPostprocessor.java
+++ b/src/main/java/ch/naviqore/raptor/router/LabelPostprocessor.java
@@ -256,7 +256,8 @@ class LabelPostprocessor {
         }
 
         // when walking goes against the trip direction, combining is not possible
-        if (fromStart ? stopTime.arrival() < routeLabel.targetTime() : stopTime.departure() > routeLabel.sourceTime()) {
+        if (fromStart ? canStopTimeBeSource(stopTime, routeLabel.targetTime(), timeType) : canStopTimeBeTarget(stopTime,
+                routeLabel.sourceTime(), timeType)) {
             return;
         }
 
@@ -288,6 +289,38 @@ class LabelPostprocessor {
             labels.removeLast();
             labels.addLast(combinedLabel);
         }
+    }
+
+    /**
+     * Check if the stop time can be the source of the route target time. This is the case if the stop time departure is
+     * before the route target time for departure time type and the stop time arrival is after the route target time for
+     * arrival time type.
+     *
+     * @param stopTime        the stop time to check.
+     * @param routeTargetTime the target time of the route, of the potential source stop time.
+     * @param timeType        the time type (arrival or departure).
+     * @return true if the stop time can be the source of the route target time, false otherwise.
+     */
+    private boolean canStopTimeBeSource(StopTime stopTime, int routeTargetTime, TimeType timeType) {
+        if (timeType == TimeType.DEPARTURE && stopTime.departure() <= routeTargetTime) {
+            return true;
+        } else return timeType == TimeType.ARRIVAL && stopTime.arrival() >= routeTargetTime;
+    }
+
+    /**
+     * Check if the stop time can be the target of the route source time. This is the case if the stop time arrival is
+     * after the route source time for departure time type and the stop time departure is before the route source time
+     * for arrival time type.
+     *
+     * @param stopTime        the stop time to check.
+     * @param routeSourceTime the source time of the route, of the potential target stop time.
+     * @param timeType        the time type (arrival or departure).
+     * @return true if the stop time can be the target of the route source time, false otherwise.
+     */
+    private boolean canStopTimeBeTarget(StopTime stopTime, int routeSourceTime, TimeType timeType) {
+        if (timeType == TimeType.DEPARTURE && stopTime.arrival() >= routeSourceTime) {
+            return true;
+        } else return timeType == TimeType.ARRIVAL && stopTime.departure() <= routeSourceTime;
     }
 
     private @Nullable StopTime getTripStopTimeForStopInTrip(int stopIdx, int routeIdx, int tripOffset) {

--- a/src/main/java/ch/naviqore/service/impl/convert/GtfsToRaptorConverter.java
+++ b/src/main/java/ch/naviqore/service/impl/convert/GtfsToRaptorConverter.java
@@ -102,15 +102,17 @@ public class GtfsToRaptorConverter {
             }
         }
 
+        // add additional transfers
         for (TransferGenerator.Transfer transfer : additionalTransfers) {
 
+            // TODO: Just overwrite with precedence order, avoid costly lookups
             if (schedule.getStops()
                     .get(transfer.from().getId())
                     .getTransfers()
                     .stream()
                     .anyMatch(t -> t.getFromStop().equals(transfer.from()) && t.getToStop()
                             .equals(transfer.to()) && t.getTransferType() == TransferType.MINIMUM_TIME)) {
-                log.warn(
+                log.debug(
                         "Omit adding additional transfer from {} to {} with duration {} as it has already been defined",
                         transfer.from().getId(), transfer.to().getId(), transfer.duration());
                 continue;


### PR DESCRIPTION
As previously discussed, I've also implemented the check for both arrival and departure time queries.

To test the implementation I've run the benchmark on the switzerland dataset both for arrival and departure.
To run arrival tests, I've modified the benchmark script as follows:

Line 128-129:
`LocalDateTime departureTime = SCHEDULE_DATE.atStartOfDay().plusSeconds(random.nextInt(DEPARTURE_TIME_LIMIT));`
becomes: 
`LocalDateTime departureTime = SCHEDULE_DATE.atStartOfDay().plusHours(24).minusSeconds(random.nextInt(DEPARTURE_TIME_LIMIT));`

Line 151:
`List<Connection> connections = raptor.routeEarliestArrival(sourceStops, targetStops, new QueryConfig());`
becomes:
`List<Connection> connections = raptor.routeLatestDeparture(targetStops, sourceStops, new QueryConfig());`