### PR TITLE
release v0.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ch.naviqore</groupId>
     <artifactId>public-transit-service</artifactId>
-    <version>0.2.1</version>
+    <version>0.3.1</version>
 
     <name>Public Transit Service</name>
     <description>


### PR DESCRIPTION
In release `v0.3.0` the version number was not set correctly in the `pom.xml` therefore the maven publish failed, sorry!

Therefore i would suggest to just release a patch with the version number set correctly and no further changes or features.