### PR TITLE
Concept/nav 135 benchmark range raptor vs. reverse routing arrival

### DIFF
--- a/src/main/java/ch/naviqore/raptor/router/Query.java
+++ b/src/main/java/ch/naviqore/raptor/router/Query.java
@@ -200,6 +200,10 @@ class Query {
             }
         }
 
+        if(rangeOffsets.isEmpty()) {
+            rangeOffsets.add(0);
+        }
+
         return rangeOffsets;
     }
 

--- a/src/main/java/ch/naviqore/raptor/router/Query.java
+++ b/src/main/java/ch/naviqore/raptor/router/Query.java
@@ -200,7 +200,7 @@ class Query {
             }
         }
 
-        if(rangeOffsets.isEmpty()) {
+        if (rangeOffsets.isEmpty()) {
             rangeOffsets.add(0);
         }
 

--- a/src/main/java/ch/naviqore/raptor/router/RaptorRouter.java
+++ b/src/main/java/ch/naviqore/raptor/router/RaptorRouter.java
@@ -47,12 +47,12 @@ public class RaptorRouter implements RaptorAlgorithm, RaptorData {
         validator = new InputValidator(lookup.stops());
     }
 
-    public static RaptorRouterBuilder builder(RaptorConfig config) {
-        return new RaptorRouterBuilder(config);
+    public void setRaptorRange(int raptorRange) {
+        config.setRaptorRange(raptorRange);
     }
 
-    public static RaptorRouter copyRouterWithDifferentConfig(RaptorRouter router, RaptorConfig config) {
-        return new RaptorRouter(router.lookup, router.stopContext, router.routeTraversal, config);
+    public static RaptorRouterBuilder builder(RaptorConfig config) {
+        return new RaptorRouterBuilder(config);
     }
 
     public void prepareStopTimesForDate(LocalDate date) {

--- a/src/main/java/ch/naviqore/raptor/router/RaptorRouter.java
+++ b/src/main/java/ch/naviqore/raptor/router/RaptorRouter.java
@@ -51,6 +51,10 @@ public class RaptorRouter implements RaptorAlgorithm, RaptorData {
         return new RaptorRouterBuilder(config);
     }
 
+    public static RaptorRouter copyRouterWithDifferentConfig(RaptorRouter router, RaptorConfig config) {
+        return new RaptorRouter(router.lookup, router.stopContext, router.routeTraversal, config);
+    }
+
     public void prepareStopTimesForDate(LocalDate date) {
         stopTimeProvider.getStopTimesForDate(date, new QueryConfig());
     }

--- a/src/main/java/ch/naviqore/raptor/router/RaptorRouter.java
+++ b/src/main/java/ch/naviqore/raptor/router/RaptorRouter.java
@@ -51,6 +51,10 @@ public class RaptorRouter implements RaptorAlgorithm, RaptorData {
         config.setRaptorRange(raptorRange);
     }
 
+    public void setDaysToScan(int daysToScan) {
+        config.setDaysToScan(daysToScan);
+    }
+
     public static RaptorRouterBuilder builder(RaptorConfig config) {
         return new RaptorRouterBuilder(config);
     }

--- a/src/main/java/ch/naviqore/raptor/simple/DateTimeUtils.java
+++ b/src/main/java/ch/naviqore/raptor/simple/DateTimeUtils.java
@@ -1,0 +1,36 @@
+package ch.naviqore.raptor.simple;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+class DateTimeUtils {
+
+    static LocalDate getReferenceDate(Map<?, LocalDateTime> sourceStops) {
+        return sourceStops.values()
+                .stream()
+                .min(Comparator.naturalOrder())
+                .map(LocalDateTime::toLocalDate)
+                .orElseThrow();
+    }
+
+    static Map<String, Integer> mapLocalDateTimeToTimestamp(Map<String, LocalDateTime> sourceStops,
+                                                            LocalDate referenceDate) {
+        return sourceStops.entrySet()
+                .stream()
+                .map(e -> Map.entry(e.getKey(), convertToTimestamp(e.getValue(), referenceDate)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    static LocalDateTime convertToLocalDateTime(int timestamp, LocalDate referenceDate) {
+        return referenceDate.atStartOfDay().plusSeconds(timestamp);
+    }
+
+    static int convertToTimestamp(LocalDateTime localDateTime, LocalDate referenceDate) {
+        return (int) Duration.between(referenceDate.atStartOfDay(), localDateTime).getSeconds();
+    }
+
+}

--- a/src/main/java/ch/naviqore/raptor/simple/FootpathRelaxer.java
+++ b/src/main/java/ch/naviqore/raptor/simple/FootpathRelaxer.java
@@ -1,0 +1,135 @@
+package ch.naviqore.raptor.simple;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import static ch.naviqore.raptor.simple.StopLabelsAndTimes.NO_INDEX;
+
+@Slf4j
+class FootpathRelaxer {
+
+    private final Transfer[] transfers;
+    private final Stop[] stops;
+
+    private final int minTransferDuration;
+    private final int maxWalkingDuration;
+
+    private final StopLabelsAndTimes stopLabelsAndTimes;
+
+    /**
+     * @param stopLabelsAndTimes      the best time per stop and label per stop and round.
+     * @param raptorData              the current raptor data structures.
+     * @param minimumTransferDuration The minimum transfer duration time, since this is intended as rest period (e.g.
+     *                                coffee break) it is added to the walk time.
+     * @param maximumWalkingDuration  The maximum walking duration to reach the target stop. If the walking duration
+     *                                exceeds this value, the target stop is not reached.
+     */
+    FootpathRelaxer(StopLabelsAndTimes stopLabelsAndTimes, RaptorData raptorData, int minimumTransferDuration,
+                    int maximumWalkingDuration) {
+        // constant data structures
+        this.transfers = raptorData.getStopContext().transfers();
+        this.stops = raptorData.getStopContext().stops();
+        // constant configuration of relaxer
+        this.minTransferDuration = minimumTransferDuration;
+        this.maxWalkingDuration = maximumWalkingDuration;
+        // note: will also change outside of relaxer, due to route scanning
+        this.stopLabelsAndTimes = stopLabelsAndTimes;
+    }
+
+    /**
+     * Relax all footpaths from all initial source stops.
+     *
+     * @param stopIndices the indices of the stops to be relaxed.
+     * @return returns the newly marked stops due to the relaxation.
+     */
+    Set<Integer> relaxInitial(int[] stopIndices) {
+        log.debug("Initial relaxing of footpaths for source stops");
+        Set<Integer> newlyMarkedStops = new HashSet<>();
+
+        for (int sourceStopIdx : stopIndices) {
+            expandFootpathsFromStop(sourceStopIdx, 0, newlyMarkedStops);
+        }
+
+        return newlyMarkedStops;
+    }
+
+    /**
+     * Relax all footpaths from marked stops.
+     *
+     * @param round       the current round.
+     * @param stopIndices the indices of the stops to be relaxed.
+     * @return returns the newly marked stops due to the relaxation.
+     */
+    Set<Integer> relax(int round, Collection<Integer> stopIndices) {
+        log.debug("Relaxing footpaths for round {}", round);
+        Set<Integer> newlyMarkedStops = new HashSet<>();
+
+        for (int sourceStopIdx : stopIndices) {
+            expandFootpathsFromStop(sourceStopIdx, round, newlyMarkedStops);
+        }
+
+        return newlyMarkedStops;
+    }
+
+    /**
+     * Expands all transfers between stops from a given stop. If a transfer improves the target time at the target stop,
+     * then the target stop is marked for the next round. And the improved target time is stored in the bestTimes array
+     * and the bestLabelPerRound list (including the new transfer label).
+     *
+     * @param stopIdx     the index of the stop to expand transfers from.
+     * @param round       the current round to relax footpaths for.
+     * @param markedStops a set of stop indices that have been marked for scanning in the next round, which will be
+     *                    extended if new stops improve due to relaxation.
+     */
+    private void expandFootpathsFromStop(int stopIdx, int round, Set<Integer> markedStops) {
+        // if stop has no transfers, then no footpaths can be expanded
+        if (stops[stopIdx].numberOfTransfers() == 0) {
+            return;
+        }
+        Stop sourceStop = stops[stopIdx];
+        StopLabelsAndTimes.Label previousLabel = stopLabelsAndTimes.getLabel(round, stopIdx);
+
+        // do not relax footpath from stop that was only reached by footpath in the same round
+        if (previousLabel == null || previousLabel.type() == StopLabelsAndTimes.LabelType.TRANSFER) {
+            return;
+        }
+
+        int sourceTime = previousLabel.targetTime();
+
+        for (int i = sourceStop.transferIdx(); i < sourceStop.transferIdx() + sourceStop.numberOfTransfers(); i++) {
+            Transfer transfer = transfers[i];
+            Stop targetStop = stops[transfer.targetStopIdx()];
+            int duration = transfer.duration();
+            if (maxWalkingDuration < duration) {
+                continue;
+            }
+
+            // calculate the target time for the transfer in the given time direction
+            int targetTime = sourceTime + transfer.duration() + minTransferDuration;
+
+            // subtract the same stop transfer time from the walk transfer target time. This accounts for the case when
+            // the walk transfer would allow to catch an earlier trip, since the route target time does not yet include
+            // the same stop transfer time.
+            int comparableTargetTime = targetTime - targetStop.sameStopTransferTime();
+
+            // if label is not improved, continue
+            if (comparableTargetTime >= stopLabelsAndTimes.getComparableBestTime(transfer.targetStopIdx())) {
+                continue;
+            }
+
+            log.debug("Stop {} was improved by transfer from stop {}", targetStop.id(), sourceStop.id());
+            // update best times with comparable target time
+            stopLabelsAndTimes.setBestTime(transfer.targetStopIdx(), comparableTargetTime);
+            // add real target time to label
+            StopLabelsAndTimes.Label label = new StopLabelsAndTimes.Label(sourceTime, targetTime,
+                    StopLabelsAndTimes.LabelType.TRANSFER, i, NO_INDEX, transfer.targetStopIdx(),
+                    stopLabelsAndTimes.getLabel(round, stopIdx));
+            stopLabelsAndTimes.setLabel(round, transfer.targetStopIdx(), label);
+            // mark stop as improved
+            markedStops.add(transfer.targetStopIdx());
+        }
+    }
+}

--- a/src/main/java/ch/naviqore/raptor/simple/LabelPostprocessor.java
+++ b/src/main/java/ch/naviqore/raptor/simple/LabelPostprocessor.java
@@ -2,7 +2,6 @@ package ch.naviqore.raptor.simple;
 
 import ch.naviqore.raptor.Connection;
 import ch.naviqore.raptor.Leg;
-import ch.naviqore.raptor.TimeType;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.LocalDate;

--- a/src/main/java/ch/naviqore/raptor/simple/LabelPostprocessor.java
+++ b/src/main/java/ch/naviqore/raptor/simple/LabelPostprocessor.java
@@ -1,0 +1,365 @@
+package ch.naviqore.raptor.simple;
+
+import ch.naviqore.raptor.Connection;
+import ch.naviqore.raptor.Leg;
+import ch.naviqore.raptor.TimeType;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static ch.naviqore.raptor.simple.StopLabelsAndTimes.INFINITY;
+
+/**
+ * Postprocessing of the raptor algorithm results. Reconstructs connections from the labels per round.
+ */
+class LabelPostprocessor {
+
+    private final Stop[] stops;
+    private final StopTime[] stopTimes;
+    private final Route[] routes;
+    private final RouteStop[] routeStops;
+
+    /**
+     * Postprocessor to convert labels into connections
+     *
+     * @param raptorData the current raptor instance for access to the data structures.
+     */
+    LabelPostprocessor(RaptorData raptorData) {
+        this.stops = raptorData.getStopContext().stops();
+        this.stopTimes = raptorData.getRouteTraversal().stopTimes();
+        this.routes = raptorData.getRouteTraversal().routes();
+        this.routeStops = raptorData.getRouteTraversal().routeStops();
+    }
+
+    /**
+     * Reconstructs isolines from the best labels per round.
+     *
+     * @param bestLabelsPerRound the best labels per round.
+     * @return a map containing the best connection to reach all stops.
+     */
+    Map<String, Connection> reconstructIsolines(List<StopLabelsAndTimes.Label[]> bestLabelsPerRound,
+                                                LocalDate referenceDate) {
+        Map<String, Connection> isolines = new HashMap<>();
+        for (int i = 0; i < stops.length; i++) {
+            Stop stop = stops[i];
+            StopLabelsAndTimes.Label bestLabelForStop = getBestLabelForStop(bestLabelsPerRound, i);
+            if (bestLabelForStop != null && bestLabelForStop.type() != StopLabelsAndTimes.LabelType.INITIAL) {
+                Connection connection = reconstructConnectionFromLabel(bestLabelForStop, referenceDate);
+                isolines.put(stop.id(), connection);
+            }
+        }
+
+        return isolines;
+    }
+
+    /**
+     * Reconstructs pareto-optimal connections from the best labels per round.
+     *
+     * @param bestLabelsPerRound the best labels per round.
+     * @return a list of pareto-optimal connections.
+     */
+    List<Connection> reconstructParetoOptimalSolutions(List<StopLabelsAndTimes.Label[]> bestLabelsPerRound,
+                                                       Map<Integer, Integer> targetStops, LocalDate referenceDate) {
+        final List<Connection> connections = new ArrayList<>();
+
+        // iterate over all rounds
+        for (StopLabelsAndTimes.Label[] labels : bestLabelsPerRound) {
+
+            StopLabelsAndTimes.Label label = null;
+            int bestTime = INFINITY;
+
+            for (Map.Entry<Integer, Integer> entry : targetStops.entrySet()) {
+                int targetStopIdx = entry.getKey();
+                int targetStopWalkingTime = entry.getValue();
+                if (labels[targetStopIdx] == null) {
+                    continue;
+                }
+                StopLabelsAndTimes.Label currentLabel = labels[targetStopIdx];
+
+                int actualArrivalTime = currentLabel.targetTime() + targetStopWalkingTime;
+                if (actualArrivalTime < bestTime) {
+                    label = currentLabel;
+                    bestTime = actualArrivalTime;
+                }
+            }
+
+            // target stop not reached in this round
+            if (label == null) {
+                continue;
+            }
+
+            Connection connection = reconstructConnectionFromLabel(label, referenceDate);
+            if (connection != null) {
+                connections.add(connection);
+            }
+        }
+
+        return connections;
+    }
+
+    private @Nullable Connection reconstructConnectionFromLabel(StopLabelsAndTimes.Label label,
+                                                                LocalDate referenceDate) {
+        RaptorConnection connection = new RaptorConnection();
+
+        ArrayList<StopLabelsAndTimes.Label> labels = new ArrayList<>();
+        while (label.type() != StopLabelsAndTimes.LabelType.INITIAL) {
+            assert label.previous() != null;
+            labels.add(label);
+            label = label.previous();
+        }
+
+        // check if first two labels can be combined (transfer + route) due to the same stop transfer penalty for route
+        // to target stop
+        maybeCombineFirstTwoLabels(labels);
+        maybeCombineLastTwoLabels(labels);
+
+        for (StopLabelsAndTimes.Label currentLabel : labels) {
+            String routeId;
+            String tripId = null;
+            assert currentLabel.previous() != null;
+            String fromStopId;
+            String toStopId;
+            int departureTimestamp;
+            int arrivalTimestamp;
+            Leg.Type type;
+            fromStopId = stops[currentLabel.previous().stopIdx()].id();
+            toStopId = stops[currentLabel.stopIdx()].id();
+            departureTimestamp = currentLabel.sourceTime();
+            arrivalTimestamp = currentLabel.targetTime();
+
+            if (currentLabel.type() == StopLabelsAndTimes.LabelType.ROUTE) {
+                Route route = routes[currentLabel.routeOrTransferIdx()];
+                routeId = route.id();
+                tripId = route.tripIds()[currentLabel.tripOffset()];
+                type = Leg.Type.ROUTE;
+            } else if (currentLabel.type() == StopLabelsAndTimes.LabelType.TRANSFER) {
+                routeId = String.format("transfer_%s_%s", fromStopId, toStopId);
+                type = Leg.Type.WALK_TRANSFER;
+            } else {
+                throw new IllegalStateException("Unknown label type");
+            }
+
+            LocalDateTime departureTime = DateTimeUtils.convertToLocalDateTime(departureTimestamp, referenceDate);
+            LocalDateTime arrivalTime = DateTimeUtils.convertToLocalDateTime(arrivalTimestamp, referenceDate);
+
+            connection.addLeg(new RaptorLeg(routeId, tripId, fromStopId, toStopId, departureTime, arrivalTime, type));
+        }
+
+        // initialize connection: Reverse order of legs and add connection
+        if (!connection.getLegs().isEmpty()) {
+            connection.initialize();
+            return connection;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Check if first two labels can be combined to one label to improve the target time. This is to catch an edge case
+     * where a transfer overwrote the best time route label because the same stop transfer time was subtracted from the
+     * walk time, this can be the case in local transit where stops are very close and can not be caught during routing,
+     * as it is not always clear if a transfer is the final label of a route (especially in Isolines where no target
+     * stop indices are provided).
+     * <p>
+     * The labels are combined to one label if the second label is a route and the last label is a transfer, the trip of
+     * the second label can reach the target stop of the first label and the route time is better than the transfer time
+     * to the target stop (either earlier arrival for time type DEPARTURE or later departure for time type ARRIVAL).
+     * <p>
+     * If the labels are combined, the first two labels are removed and the combined label is added to the list of
+     * labels.
+     *
+     * @param labels the list of labels to check for combination.
+     */
+    private void maybeCombineFirstTwoLabels(ArrayList<StopLabelsAndTimes.Label> labels) {
+        maybeCombineLabels(labels, true);
+    }
+
+    /**
+     * Check if last two labels can be combined to one label to improve the target time. This is because by default the
+     * raptor algorithm will relax footpaths from the source stop at the earliest possible time (i.e. the given arrival
+     * time or departure time), however, if the transfer reaches a nearby stop and the second leg (second last label) is
+     * a route trip that could have also been entered at the source stop, it is possible that the overall travel time
+     * can be reduced by combining the two labels. The earliest arrival time or latest departure time is not changed by
+     * this operation, but the travel time is reduced. If the labels cannot be combined because the route trip does not
+     * pass through the source stop, the transfer label is shifted in time that there is no idleTime between the
+     * transfer and the route trip (see maybeShiftSourceTransferCloserToFirstRoute).
+     * <p>
+     * Example: if the departure time is set to 5 am at Stop A and a connection to stop C is queried, the algorithm will
+     * relax footpaths from Stop A at 5 am and reach Stop B at 5:05 am. However, the earliest trip on the route
+     * travelling from Stop A - B - C leaves at 9:00 am and arrives at C at 9:07. As a consequence, the arrival time for
+     * the connection Transfer A (5:00 am) - B (5:05 am) - Route B (9:03 am) - C (9:07 am) is 9:07 am and the connection
+     * Route A (9:00 am) - B (9:03 am) - C (9:07 am) is 9:07 am will be identical. However, the latter connection will
+     * have travel time of 7 minutes, whereas the former connection will have a travel time of 3 hours and 7 minutes and
+     * is therefore less convenient.
+     *
+     * @param labels the list of labels to check for combination.
+     */
+    private void maybeCombineLastTwoLabels(ArrayList<StopLabelsAndTimes.Label> labels) {
+        maybeCombineLabels(labels, false);
+    }
+
+    /**
+     * Implementation for the two method above (maybeCombineFirstTwoLabels and maybeCombineLastTwoLabels). For more info
+     * see the documentation of the two methods.
+     *
+     * @param labels     the list of labels to check for combination.
+     * @param fromTarget if true, the first two labels are checked, if false, the last two labels (first two legs of
+     *                   connection) are checked. Note the first two labels are the two labels closest to the target!
+     */
+    private void maybeCombineLabels(ArrayList<StopLabelsAndTimes.Label> labels, boolean fromTarget) {
+        if (labels.size() < 2) {
+            return;
+        }
+
+        // define the indices of the labels to check (first two or last two)
+        int transferLabelIndex = fromTarget ? 0 : labels.size() - 1;
+        int routeLabelIndex = fromTarget ? 1 : labels.size() - 2;
+
+        StopLabelsAndTimes.Label transferLabel = labels.get(transferLabelIndex);
+        StopLabelsAndTimes.Label routeLabel = labels.get(routeLabelIndex);
+
+        // check if the labels are of the correct type else they cannot be combined
+        if (transferLabel.type() != StopLabelsAndTimes.LabelType.TRANSFER || routeLabel.type() != StopLabelsAndTimes.LabelType.ROUTE) {
+            return;
+        }
+
+        int stopIdx;
+        if (fromTarget) {
+            stopIdx = transferLabel.stopIdx();
+        } else {
+            assert transferLabel.previous() != null;
+            stopIdx = transferLabel.previous().stopIdx();
+        }
+
+        StopTime stopTime = getTripStopTimeForStopInTrip(stopIdx, routeLabel.routeOrTransferIdx(),
+                routeLabel.tripOffset());
+
+        // if stopTime is null, then the stop is not part of the trip of the route label, if stop time is not null, then
+        // check if the temporal order of the stop time and the route label is correct (e.g. for time type departure the
+        // stop time departure must be before the route label target time)
+        if (stopTime == null || (fromTarget ? !canStopTimeBeTarget(stopTime,
+                routeLabel.targetTime()) : !canStopTimeBeSource(stopTime, routeLabel.sourceTime()))) {
+            if (!fromTarget) {
+                maybeShiftSourceTransferCloserToFirstRoute(labels, transferLabel, routeLabel, transferLabelIndex);
+            }
+            return;
+        }
+
+        int routeTime = fromTarget ? stopTime.arrival() : stopTime.departure();
+
+        // this is the best time achieved with the route / transfer combination
+        int referenceTime = fromTarget ? transferLabel.targetTime() : transferLabel.sourceTime();
+
+        // if the best time is not improved, then the labels should not be combined
+        if (fromTarget ? (routeTime > referenceTime) : (routeTime < referenceTime)) {
+            return;
+        }
+
+        // combine and replace labels
+        if (fromTarget) {
+            StopLabelsAndTimes.Label combinedLabel = new StopLabelsAndTimes.Label(routeLabel.sourceTime(), routeTime,
+                    StopLabelsAndTimes.LabelType.ROUTE, routeLabel.routeOrTransferIdx(), routeLabel.tripOffset(),
+                    transferLabel.stopIdx(), routeLabel.previous());
+            labels.removeFirst();
+            labels.removeFirst();
+            labels.addFirst(combinedLabel);
+        } else {
+            StopLabelsAndTimes.Label combinedLabel = new StopLabelsAndTimes.Label(routeTime, routeLabel.targetTime(),
+                    StopLabelsAndTimes.LabelType.ROUTE, routeLabel.routeOrTransferIdx(), routeLabel.tripOffset(),
+                    routeLabel.stopIdx(), transferLabel.previous());
+            labels.removeLast();
+            labels.removeLast();
+            labels.addLast(combinedLabel);
+        }
+    }
+
+    /**
+     * This method checks if there is idle time between the source transfer (note this method expects that is only
+     * applied on source labels of type transfer) and the first route label. If there is idle time, i.e. the transfer
+     * arrives/leaves not directly before/after the route departs/arrives, then the transfer label can be shifted to the
+     * route label (shortening the travel time).
+     *
+     * @param labels             the list of all labels for the connection
+     * @param transferLabel      the source transfer label
+     * @param routeLabel         the following route label
+     * @param transferLabelIndex the index of the transfer label in the list of labels (either last or first)
+     */
+    private void maybeShiftSourceTransferCloserToFirstRoute(ArrayList<StopLabelsAndTimes.Label> labels,
+                                                            StopLabelsAndTimes.Label transferLabel,
+                                                            StopLabelsAndTimes.Label routeLabel,
+                                                            int transferLabelIndex) {
+        // if there is idle time (a gap between the initial or final transfer and route) then the transfer label can
+        // be shifted to the route label (shortening the travel time)
+        int idleTime = routeLabel.sourceTime() - transferLabel.targetTime();
+        if (idleTime != 0) {
+            labels.set(transferLabelIndex, new StopLabelsAndTimes.Label(transferLabel.sourceTime() + idleTime,
+                    transferLabel.targetTime() + idleTime, StopLabelsAndTimes.LabelType.TRANSFER,
+                    transferLabel.routeOrTransferIdx(), transferLabel.tripOffset(), transferLabel.stopIdx(),
+                    transferLabel.previous()));
+        }
+
+    }
+
+    /**
+     * Check if the stop time can be the source of the route target time. This is the case if the stop time departure is
+     * before the route target time for departure time type and the stop time arrival is after the route target time for
+     * arrival time type.
+     *
+     * @param stopTime        the stop time to check.
+     * @param routeTargetTime the target time of the route, of the potential source stop time.
+     * @return true if the stop time can be the source of the route target time, false otherwise.
+     */
+    private boolean canStopTimeBeSource(StopTime stopTime, int routeTargetTime) {
+        return stopTime.departure() <= routeTargetTime;
+    }
+
+    /**
+     * Check if the stop time can be the target of the route source time. This is the case if the stop time arrival is
+     * after the route source time for departure time type and the stop time departure is before the route source time
+     * for arrival time type.
+     *
+     * @param stopTime        the stop time to check.
+     * @param routeSourceTime the source time of the route, of the potential target stop time.
+     * @return true if the stop time can be the target of the route source time, false otherwise.
+     */
+    private boolean canStopTimeBeTarget(StopTime stopTime, int routeSourceTime) {
+        return stopTime.arrival() >= routeSourceTime;
+    }
+
+    private @Nullable StopTime getTripStopTimeForStopInTrip(int stopIdx, int routeIdx, int tripOffset) {
+        int firstStopTimeIdx = routes[routeIdx].firstStopTimeIdx();
+        int numberOfStops = routes[routeIdx].numberOfStops();
+
+        int stopOffset = -1;
+        for (int i = 0; i < numberOfStops; i++) {
+            if (routeStops[routes[routeIdx].firstRouteStopIdx() + i].stopIndex() == stopIdx) {
+                stopOffset = i;
+                break;
+            }
+        }
+
+        if (stopOffset == -1) {
+            return null;
+        }
+
+        return stopTimes[firstStopTimeIdx + tripOffset * numberOfStops + stopOffset];
+    }
+
+    private @Nullable StopLabelsAndTimes.Label getBestLabelForStop(List<StopLabelsAndTimes.Label[]> bestLabelsPerRound,
+                                                                   int stopIdx) {
+        // Loop through the list in reverse order since the first occurrence will be the best target time
+        for (int i = bestLabelsPerRound.size() - 1; i >= 0; i--) {
+            StopLabelsAndTimes.Label label = bestLabelsPerRound.get(i)[stopIdx];
+            if (label != null) {
+                return label;
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/ch/naviqore/raptor/simple/Lookup.java
+++ b/src/main/java/ch/naviqore/raptor/simple/Lookup.java
@@ -1,0 +1,6 @@
+package ch.naviqore.raptor.simple;
+
+import java.util.Map;
+
+record Lookup(Map<String, Integer> stops, Map<String, Integer> routes) {
+}

--- a/src/main/java/ch/naviqore/raptor/simple/Query.java
+++ b/src/main/java/ch/naviqore/raptor/simple/Query.java
@@ -1,7 +1,6 @@
 package ch.naviqore.raptor.simple;
 
 import ch.naviqore.raptor.QueryConfig;
-import ch.naviqore.raptor.TimeType;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Arrays;

--- a/src/main/java/ch/naviqore/raptor/simple/Query.java
+++ b/src/main/java/ch/naviqore/raptor/simple/Query.java
@@ -1,0 +1,214 @@
+package ch.naviqore.raptor.simple;
+
+import ch.naviqore.raptor.QueryConfig;
+import ch.naviqore.raptor.TimeType;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static ch.naviqore.raptor.simple.StopLabelsAndTimes.INFINITY;
+
+/**
+ * The query represents a request to the raptor router and coordinates the routing logic. Each request needs a new query
+ * instance.
+ */
+@Slf4j
+class Query {
+
+    private final int[] sourceStopIndices;
+    private final int[] targetStopIndices;
+    private final int[] sourceTimes;
+    private final int[] walkingDurationsToTarget;
+
+    private final RaptorData raptorData;
+    private final QueryConfig config;
+
+    private final int[] targetStops;
+    private final int cutoffTime;
+    private final StopLabelsAndTimes stopLabelsAndTimes;
+
+    /**
+     * @param raptorData               the current raptor data structures.
+     * @param sourceStopIndices        the indices of the source stops.
+     * @param targetStopIndices        the indices of the target stops.
+     * @param sourceTimes              the start times at the source stops.
+     * @param walkingDurationsToTarget the walking durations to the target stops.
+     * @param config                   the query configuration.
+     */
+    Query(RaptorData raptorData, int[] sourceStopIndices, int[] targetStopIndices, int[] sourceTimes,
+          int[] walkingDurationsToTarget, QueryConfig config) {
+
+        if (sourceStopIndices.length != sourceTimes.length) {
+            throw new IllegalArgumentException("Source stops and departure/arrival times must have the same size.");
+        }
+
+        if (targetStopIndices.length != walkingDurationsToTarget.length) {
+            throw new IllegalArgumentException("Target stops and walking durations to target must have the same size.");
+        }
+
+        this.raptorData = raptorData;
+        this.sourceStopIndices = sourceStopIndices;
+        this.targetStopIndices = targetStopIndices;
+        this.sourceTimes = sourceTimes;
+        this.walkingDurationsToTarget = walkingDurationsToTarget;
+        this.config = config;
+
+        targetStops = new int[targetStopIndices.length * 2];
+        cutoffTime = determineCutoffTime();
+        stopLabelsAndTimes = new StopLabelsAndTimes(raptorData.getStopContext().stops().length);
+    }
+
+    /**
+     * Main control flow of the routing algorithm. Spawns from source stops, coordinates route scanning, footpath
+     * relaxation, and time/label updates in the correct order.
+     * <p>
+     * The process starts by relaxing all source stops and adding the newly improved stops by relaxation to the set of
+     * marked stops. It then iterates through rounds of route scanning and footpath relaxation until no new stops are
+     * marked or the maximum number of transfers is reached.
+     * <p>
+     * Each round includes the following steps:
+     * <ul>
+     *     <li>Add a new label layer for the current round.</li>
+     *     <li>Scan all routes and mark stops that have improved.</li>
+     *     <li>Relax footpaths for all newly marked stops.</li>
+     *     <li>Prepare for the next round by removing suboptimal labels.</li>
+     * </ul>
+     */
+    List<StopLabelsAndTimes.Label[]> run() {
+        // set up footpath relaxer and route scanner and inject stop labels and times
+        FootpathRelaxer footpathRelaxer = new FootpathRelaxer(stopLabelsAndTimes, raptorData,
+                config.getMinimumTransferDuration(), config.getMaximumWalkingDuration());
+        RouteScanner routeScanner = new RouteScanner(stopLabelsAndTimes, raptorData,
+                config.getMinimumTransferDuration());
+
+        // initially relax all source stops and add the newly improved stops by relaxation to the marked stops
+        Set<Integer> markedStops = initialize();
+        markedStops.addAll(footpathRelaxer.relaxInitial(sourceStopIndices));
+        markedStops = removeSuboptimalLabelsForRound(0, markedStops);
+
+        // continue with further rounds as long as there are new marked stops
+        int round = 1;
+        while (!markedStops.isEmpty() && (round - 1) <= config.getMaximumTransferNumber()) {
+            // add label layer for new round
+            stopLabelsAndTimes.addNewRound();
+
+            // scan all routs and mark stops that have improved
+            Set<Integer> markedStopsNext = routeScanner.scan(round, markedStops);
+
+            // relax footpaths for all newly marked stops
+            markedStopsNext.addAll(footpathRelaxer.relax(round, markedStopsNext));
+
+            // prepare next round
+            markedStops = removeSuboptimalLabelsForRound(round, markedStopsNext);
+            round++;
+        }
+
+        return stopLabelsAndTimes.getBestLabelsPerRound();
+    }
+
+    /**
+     * Set up the best times per stop and best labels per round for a new query.
+     *
+     * @return the initially marked stops.
+     */
+    Set<Integer> initialize() {
+        log.info("Initializing global best times per stop and best labels per round");
+
+        // fill target stops
+        for (int i = 0; i < targetStops.length; i += 2) {
+            int index = (int) Math.ceil(i / 2.0);
+            targetStops[i] = targetStopIndices[index];
+            targetStops[i + 1] = walkingDurationsToTarget[index];
+        }
+
+        // set initial labels, best time and mark source stops
+        Set<Integer> markedStops = new HashSet<>();
+        for (int i = 0; i < sourceStopIndices.length; i++) {
+            int currentStopIdx = sourceStopIndices[i];
+            int targetTime = sourceTimes[i];
+
+            StopLabelsAndTimes.Label label = new StopLabelsAndTimes.Label(0, targetTime,
+                    StopLabelsAndTimes.LabelType.INITIAL, StopLabelsAndTimes.NO_INDEX, StopLabelsAndTimes.NO_INDEX,
+                    currentStopIdx, null);
+            stopLabelsAndTimes.setLabel(0, currentStopIdx, label);
+            stopLabelsAndTimes.setBestTime(currentStopIdx, targetTime);
+
+            markedStops.add(currentStopIdx);
+        }
+
+        return markedStops;
+    }
+
+    /**
+     * Nullify labels that are suboptimal for the current round. This method checks if the label time is worse than the
+     * optimal time mark and removes the mark for the next round and nullifies the label in this case.
+     *
+     * @param round       the round to remove suboptimal labels for.
+     * @param markedStops the marked stops to check for suboptimal labels.
+     */
+    Set<Integer> removeSuboptimalLabelsForRound(int round, Set<Integer> markedStops) {
+        int bestTime = getBestTimeForAllTargetStops();
+
+        if (bestTime == INFINITY || bestTime == -INFINITY) {
+            return markedStops;
+        }
+
+        Set<Integer> markedStopsClean = new HashSet<>();
+        for (int stopIdx : markedStops) {
+            StopLabelsAndTimes.Label label = stopLabelsAndTimes.getLabel(round, stopIdx);
+            if (label != null) {
+                if (label.targetTime() > bestTime) {
+                    stopLabelsAndTimes.setLabel(round, stopIdx, null);
+                } else {
+                    markedStopsClean.add(stopIdx);
+                }
+            }
+        }
+
+        return markedStopsClean;
+    }
+
+    /**
+     * Get the best time for the target stops. The best time is the earliest arrival time for each stop if the time type
+     * is departure, and the latest arrival time for each stop if the time type is arrival.
+     */
+    private int getBestTimeForAllTargetStops() {
+        int bestTime = cutoffTime;
+
+        for (int i = 0; i < targetStops.length; i += 2) {
+            int targetStopIdx = targetStops[i];
+            int walkDurationToTarget = targetStops[i + 1];
+            int bestTimeForStop = stopLabelsAndTimes.getActualBestTime(targetStopIdx);
+
+            if (bestTimeForStop != INFINITY) {
+                bestTimeForStop += walkDurationToTarget;
+                bestTime = Math.min(bestTime, bestTimeForStop);
+            }
+        }
+
+        return bestTime;
+    }
+
+    /**
+     * The cut-off time is the latest allowed arrival / the earliest allowed departure time, if a stop is reached
+     * after/before (depending on timeType), the stop is no longer considered for further expansion.
+     *
+     * @return the cut-off time.
+     */
+    private int determineCutoffTime() {
+        int cutoffTime;
+
+        if (config.getMaximumTravelTime() == INFINITY) {
+            cutoffTime = INFINITY;
+        } else {
+            int earliestDeparture = Arrays.stream(sourceTimes).min().orElseThrow();
+            cutoffTime = earliestDeparture + config.getMaximumTravelTime();
+        }
+
+        return cutoffTime;
+    }
+
+}

--- a/src/main/java/ch/naviqore/raptor/simple/Query.java
+++ b/src/main/java/ch/naviqore/raptor/simple/Query.java
@@ -152,7 +152,7 @@ class Query {
     Set<Integer> removeSuboptimalLabelsForRound(int round, Set<Integer> markedStops) {
         int bestTime = getBestTimeForAllTargetStops();
 
-        if (bestTime == INFINITY || bestTime == -INFINITY) {
+        if (bestTime == INFINITY) {
             return markedStops;
         }
 

--- a/src/main/java/ch/naviqore/raptor/simple/RaptorConnection.java
+++ b/src/main/java/ch/naviqore/raptor/simple/RaptorConnection.java
@@ -1,0 +1,106 @@
+package ch.naviqore.raptor.simple;
+
+import ch.naviqore.raptor.Connection;
+import ch.naviqore.raptor.Leg;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@Getter
+@ToString
+class RaptorConnection implements Connection {
+
+    private List<Leg> legs = new ArrayList<>();
+
+    private static void validateLegOrder(Leg current, Leg next) {
+        if (!current.getToStopId().equals(next.getFromStopId())) {
+            throw new IllegalStateException("Legs are not connected: " + current + " -> " + next);
+        }
+        if (current.getArrivalTime().isBefore(current.getDepartureTime())) {
+            throw new IllegalStateException("Arrival time must be after departure time: " + current);
+        }
+        if (current.getArrivalTime().isAfter(next.getDepartureTime())) {
+            throw new IllegalStateException(
+                    "Arrival time must be before next departure time: " + current + " -> " + next);
+        }
+    }
+
+    void addLeg(Leg leg) {
+        this.legs.add(leg);
+    }
+
+    void initialize() {
+        // sort legs by departure time
+        Collections.sort(legs);
+        // make sure that the legs are connected and times are consistent
+        for (int i = 0; i < legs.size() - 1; i++) {
+            Leg current = legs.get(i);
+            Leg next = legs.get(i + 1);
+            validateLegOrder(current, next);
+        }
+        // make legs immutable and remove unnecessary allocated memory
+        this.legs = List.copyOf(legs);
+    }
+
+    @Override
+    public LocalDateTime getDepartureTime() {
+        return legs.getFirst().getDepartureTime();
+    }
+
+    @Override
+    public LocalDateTime getArrivalTime() {
+        return legs.getLast().getArrivalTime();
+    }
+
+    @Override
+    public String getFromStopId() {
+        return legs.getFirst().getFromStopId();
+    }
+
+    @Override
+    public String getToStopId() {
+        return legs.getLast().getToStopId();
+    }
+
+    @Override
+    public int getDurationInSeconds() {
+        return (int) Duration.between(getDepartureTime(), getArrivalTime()).getSeconds();
+    }
+
+    @Override
+    public List<Leg> getWalkTransfers() {
+        return legs.stream().filter(l -> l.getType() == Leg.Type.WALK_TRANSFER).toList();
+    }
+
+    @Override
+    public List<Leg> getRouteLegs() {
+        return legs.stream().filter(l -> l.getType() == Leg.Type.ROUTE).toList();
+    }
+
+    @Override
+    public int getNumberOfSameStopTransfers() {
+        int transferCounter = 0;
+        for (int i = 0; i < legs.size() - 1; i++) {
+            Leg current = legs.get(i);
+            Leg next = legs.get(i + 1);
+            if (current.getType() == Leg.Type.ROUTE && next.getType() == Leg.Type.ROUTE) {
+                transferCounter++;
+            }
+        }
+        return transferCounter;
+    }
+
+    @Override
+    public int getNumberOfTotalTransfers() {
+        return getWalkTransfers().size() + getNumberOfSameStopTransfers();
+    }
+
+}

--- a/src/main/java/ch/naviqore/raptor/simple/RaptorData.java
+++ b/src/main/java/ch/naviqore/raptor/simple/RaptorData.java
@@ -1,0 +1,14 @@
+package ch.naviqore.raptor.simple;
+
+/**
+ * Internal interface to provide access to data structures required for the raptor routing.
+ */
+interface RaptorData {
+
+    Lookup getLookup();
+
+    StopContext getStopContext();
+
+    RouteTraversal getRouteTraversal();
+
+}

--- a/src/main/java/ch/naviqore/raptor/simple/RaptorLeg.java
+++ b/src/main/java/ch/naviqore/raptor/simple/RaptorLeg.java
@@ -1,0 +1,58 @@
+package ch.naviqore.raptor.simple;
+
+import ch.naviqore.raptor.Leg;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+@Getter
+@ToString
+class RaptorLeg implements Leg {
+
+    private final String routeId;
+    private final @Nullable String tripId;
+    private final String fromStopId;
+    private final String toStopId;
+    private final LocalDateTime departureTime;
+    private final LocalDateTime arrivalTime;
+    private final Type type;
+
+    @Override
+    public int compareTo(@NotNull Leg other) {
+        // sort legs first by departure time than by arrival time since there some legs that actually have the same
+        // departure and arrival time (really short distance local service) and therefore the following leg may
+        // have the same departure time but a later arrival time
+        int comparison = getDepartureTime().compareTo(other.getDepartureTime());
+        if (comparison != 0) {
+            return comparison;
+        } else {
+            return getArrivalTime().compareTo(other.getArrivalTime());
+        }
+
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (Leg) obj;
+        return Objects.equals(this.routeId, that.getRouteId()) && Objects.equals(this.tripId,
+                that.getTripId()) && Objects.equals(this.fromStopId, that.getFromStopId()) && Objects.equals(
+                this.toStopId,
+                that.getToStopId()) && this.getArrivalTime() == that.getArrivalTime() && this.getDepartureTime() == that.getDepartureTime() && Objects.equals(
+                this.type, that.getType());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(routeId, tripId, fromStopId, toStopId, departureTime, arrivalTime, type);
+    }
+
+}

--- a/src/main/java/ch/naviqore/raptor/simple/RaptorRouterBuilder.java
+++ b/src/main/java/ch/naviqore/raptor/simple/RaptorRouterBuilder.java
@@ -1,0 +1,236 @@
+package ch.naviqore.raptor.simple;
+
+import ch.naviqore.raptor.RaptorAlgorithm;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+import static ch.naviqore.raptor.simple.StopLabelsAndTimes.NO_INDEX;
+
+/**
+ * Builds the Raptor and its internal data structures. Ensures that all stops, routes, trips, stop times, and transfers
+ * are correctly added and validated before constructing the Raptor model:
+ * <ul>
+ *     <li>All stops must have at least one route serving them.</li>
+ *     <li>All stops of a route must be known before adding the route.</li>
+ *     <li>All trips of a route must have the same stop sequence.</li>
+ *     <li>Each stop time of a trip must have a departure time after the previous stop time's arrival time.</li>
+ *     <li>All trips in the final route container must be sorted by departure time.</li>
+ * </ul>
+ *
+ * @author munterfi
+ */
+@Slf4j
+public class RaptorRouterBuilder {
+
+    private final int defaultSameStopTransferTime;
+    private final Map<String, Integer> stops = new HashMap<>();
+    private final Map<String, RouteBuilder> routeBuilders = new HashMap<>();
+    private final Map<String, List<Transfer>> transfers = new HashMap<>();
+    private final Map<String, Integer> sameStopTransfers = new HashMap<>();
+    private final Map<String, Set<String>> stopRoutes = new HashMap<>();
+
+    int stopTimeSize = 0;
+    int routeStopSize = 0;
+    int transferSize = 0;
+
+    public RaptorRouterBuilder(int defaultSameStopTransferTime) {
+        this.defaultSameStopTransferTime = defaultSameStopTransferTime;
+    }
+
+    public RaptorRouterBuilder addStop(String id) {
+        if (stops.containsKey(id)) {
+            throw new IllegalArgumentException("Stop " + id + " already exists");
+        }
+
+        log.debug("Adding stop: id={}", id);
+        stops.put(id, stops.size());
+        stopRoutes.put(id, new HashSet<>());
+
+        return this;
+    }
+
+    public RaptorRouterBuilder addRoute(String id, List<String> stopIds) {
+        if (routeBuilders.containsKey(id)) {
+            throw new IllegalArgumentException("Route " + id + " already exists");
+        }
+
+        for (String stopId : stopIds) {
+            if (!stops.containsKey(stopId)) {
+                throw new IllegalArgumentException("Stop " + stopId + " does not exist");
+            }
+            stopRoutes.get(stopId).add(id);
+        }
+
+        log.debug("Adding route: id={}, stopSequence={}", id, stopIds);
+        routeBuilders.put(id, new RouteBuilder(id, stopIds));
+        routeStopSize += stopIds.size();
+
+        return this;
+    }
+
+    public RaptorRouterBuilder addTrip(String tripId, String routeId) {
+        getRouteBuilder(routeId).addTrip(tripId);
+        return this;
+    }
+
+    public RaptorRouterBuilder addStopTime(String routeId, String tripId, int position, String stopId, int arrival,
+                                           int departure) {
+        StopTime stopTime = new StopTime(arrival, departure);
+        getRouteBuilder(routeId).addStopTime(tripId, position, stopId, stopTime);
+        stopTimeSize++;
+
+        return this;
+    }
+
+    public RaptorRouterBuilder addTransfer(String sourceStopId, String targetStopId, int duration) {
+        log.debug("Adding transfer: sourceStopId={}, targetStopId={}, duration={}", sourceStopId, targetStopId,
+                duration);
+
+        if (!stops.containsKey(sourceStopId)) {
+            throw new IllegalArgumentException("Source stop " + sourceStopId + " does not exist");
+        }
+
+        if (!stops.containsKey(targetStopId)) {
+            throw new IllegalArgumentException("Target stop " + targetStopId + " does not exist");
+        }
+
+        if (sourceStopId.equals(targetStopId)) {
+            sameStopTransfers.put(sourceStopId, duration);
+            return this;
+        }
+
+        transfers.computeIfAbsent(sourceStopId, k -> new ArrayList<>())
+                .add(new Transfer(stops.get(targetStopId), duration));
+        transferSize++;
+
+        return this;
+    }
+
+    public RaptorAlgorithm build() {
+        log.info("Initialize Raptor with {} stops, {} routes, {} route stops, {} stop times, {} transfers",
+                stops.size(), routeBuilders.size(), routeStopSize, stopTimeSize, transferSize);
+
+        // build route containers and the raptor array-based data structures
+        List<RouteBuilder.RouteContainer> routeContainers = buildAndSortRouteContainers();
+        Lookup lookup = buildLookup(routeContainers);
+        StopContext stopContext = buildStopContext(lookup);
+        RouteTraversal routeTraversal = buildRouteTraversal(routeContainers);
+
+        return new SimpleRaptorRouter(lookup, stopContext, routeTraversal);
+    }
+
+    private @NotNull List<RouteBuilder.RouteContainer> buildAndSortRouteContainers() {
+        return routeBuilders.values().parallelStream().map(RouteBuilder::build).sorted().toList();
+    }
+
+    private Lookup buildLookup(List<RouteBuilder.RouteContainer> routeContainers) {
+        log.debug("Building lookup with {} stops and {} routes", stops.size(), routeContainers.size());
+        Map<String, Integer> routes = new HashMap<>(routeContainers.size());
+
+        // assign idx to routes based on sorted order
+        for (int i = 0; i < routeContainers.size(); i++) {
+            RouteBuilder.RouteContainer routeContainer = routeContainers.get(i);
+            routes.put(routeContainer.id(), i);
+        }
+
+        return new Lookup(Map.copyOf(stops), Map.copyOf(routes));
+    }
+
+    private StopContext buildStopContext(Lookup lookup) {
+        log.debug("Building stop context with {} stops and {} transfers", stops.size(), transferSize);
+
+        // allocate arrays in needed size
+        Stop[] stopArr = new Stop[stops.size()];
+        int[] stopRouteArr = new int[stopRoutes.values().stream().mapToInt(Set::size).sum()];
+        Transfer[] transferArr = new Transfer[transferSize];
+
+        // iterate over stops and populate arrays
+        int transferIdx = 0;
+        int stopRouteIdx = 0;
+        for (Map.Entry<String, Integer> entry : stops.entrySet()) {
+            String stopId = entry.getKey();
+            int stopIdx = entry.getValue();
+
+            // check if stop has no routes: Unserved stops are useless in the raptor data structure
+            Set<String> currentStopRoutes = stopRoutes.get(stopId);
+            if (currentStopRoutes == null) {
+                throw new IllegalStateException("Stop " + stopId + " has no routes");
+            }
+
+            // get the number of (optional) transfers
+            List<Transfer> currentTransfers = transfers.get(stopId);
+            int numberOfTransfers = currentTransfers == null ? 0 : currentTransfers.size();
+
+            int sameStopTransferTime = sameStopTransfers.getOrDefault(stopId, defaultSameStopTransferTime);
+
+            // add stop entry to stop array
+            stopArr[stopIdx] = new Stop(stopId, stopRouteIdx, currentStopRoutes.size(), sameStopTransferTime,
+                    numberOfTransfers == 0 ? NO_INDEX : transferIdx, numberOfTransfers);
+
+            // add transfer entry to transfer array if there are any
+            if (currentTransfers != null) {
+                for (Transfer transfer : currentTransfers) {
+                    transferArr[transferIdx++] = transfer;
+                }
+            }
+
+            // add route index entries to stop route array
+            for (String routeId : currentStopRoutes) {
+                stopRouteArr[stopRouteIdx++] = lookup.routes().get(routeId);
+            }
+        }
+
+        return new StopContext(transferArr, stopArr, stopRouteArr);
+    }
+
+    private RouteTraversal buildRouteTraversal(List<RouteBuilder.RouteContainer> routeContainers) {
+        log.debug("Building route traversal with {} routes, {} route stops, {} stop times", routeContainers.size(),
+                routeStopSize, stopTimeSize);
+
+        // allocate arrays in needed size
+        Route[] routeArr = new Route[routeContainers.size()];
+        RouteStop[] routeStopArr = new RouteStop[routeStopSize];
+        StopTime[] stopTimeArr = new StopTime[stopTimeSize];
+
+        // iterate over routes and populate arrays
+        int routeStopCnt = 0;
+        int stopTimeCnt = 0;
+        for (int routeIdx = 0; routeIdx < routeContainers.size(); routeIdx++) {
+            RouteBuilder.RouteContainer routeContainer = routeContainers.get(routeIdx);
+
+            // add route entry to route array
+            final int numberOfStops = routeContainer.stopSequence().size();
+            final int numberOfTrips = routeContainer.trips().size();
+            routeArr[routeIdx] = new Route(routeContainer.id(), routeStopCnt, numberOfStops, stopTimeCnt, numberOfTrips,
+                    routeContainer.trips().keySet().toArray(new String[0]));
+
+            // add stops to route stop array
+            Map<Integer, String> stopSequence = routeContainer.stopSequence();
+            for (int position = 0; position < numberOfStops; position++) {
+                int stopIdx = stops.get(stopSequence.get(position));
+                routeStopArr[routeStopCnt++] = new RouteStop(stopIdx, routeIdx);
+            }
+
+            // add times to stop time array
+            for (StopTime[] stopTimes : routeContainer.trips().values()) {
+                for (StopTime stopTime : stopTimes) {
+                    stopTimeArr[stopTimeCnt++] = stopTime;
+                }
+            }
+        }
+
+        return new RouteTraversal(stopTimeArr, routeArr, routeStopArr);
+    }
+
+    private @NotNull RouteBuilder getRouteBuilder(String routeId) {
+        RouteBuilder routeBuilder = routeBuilders.get(routeId);
+        if (routeBuilder == null) {
+            throw new IllegalArgumentException("Route " + routeId + " does not exist");
+        }
+
+        return routeBuilder;
+    }
+
+}

--- a/src/main/java/ch/naviqore/raptor/simple/Route.java
+++ b/src/main/java/ch/naviqore/raptor/simple/Route.java
@@ -1,0 +1,5 @@
+package ch.naviqore.raptor.simple;
+
+record Route(String id, int firstRouteStopIdx, int numberOfStops, int firstStopTimeIdx, int numberOfTrips,
+             String[] tripIds) {
+}

--- a/src/main/java/ch/naviqore/raptor/simple/RouteBuilder.java
+++ b/src/main/java/ch/naviqore/raptor/simple/RouteBuilder.java
@@ -1,0 +1,125 @@
+package ch.naviqore.raptor.simple;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+/**
+ * Builds route containers that hold valid trips for a given route.
+ * <p>
+ * The builder ensures that:
+ * <ul>
+ *     <li>All trips of a route have the same stop sequence.</li>
+ *     <li>Each stop time of a trip has a departure time that is temporally after the previous stop time's arrival time.</li>
+ *     <li>In the final route container all trips are sorted according to their departure time.</li>
+ * </ul>
+ */
+@Slf4j
+class RouteBuilder {
+
+    private final String routeId;
+    private final Map<Integer, String> stopSequence = new HashMap<>();
+    private final Map<String, StopTime[]> trips = new HashMap<>();
+
+    RouteBuilder(String routeId, List<String> stopIds) {
+        this.routeId = routeId;
+        for (int i = 0; i < stopIds.size(); i++) {
+            stopSequence.put(i, stopIds.get(i));
+        }
+    }
+
+    void addTrip(String tripId) {
+        log.debug("Adding trip: id={} routeId={}", tripId, routeId);
+        if (trips.containsKey(tripId)) {
+            throw new IllegalArgumentException("Trip " + tripId + " already exists.");
+        }
+        trips.put(tripId, new StopTime[stopSequence.size()]);
+    }
+
+    void addStopTime(String tripId, int position, String stopId, StopTime stopTime) {
+        log.debug("Adding stop time: tripId={}, position={}, stopId={}, stopTime={}", tripId, position, stopId,
+                stopTime);
+
+        if (position < 0 || position >= stopSequence.size()) {
+            throw new IllegalArgumentException(
+                    "Position " + position + " is out of bounds [0, " + stopSequence.size() + ").");
+        }
+
+        StopTime[] stopTimes = trips.get(tripId);
+        if (stopTimes == null) {
+            throw new IllegalArgumentException("Trip " + tripId + " does not exist.");
+        }
+
+        if (!stopSequence.get(position).equals(stopId)) {
+            throw new IllegalArgumentException("Stop " + stopId + " does not match stop " + stopSequence.get(
+                    position) + " at position " + position + ".");
+        }
+
+        if (stopTimes[position] != null) {
+            throw new IllegalArgumentException("Stop time for stop " + stopId + " already exists.");
+        }
+
+        if (position > 0) {
+            StopTime previousStopTime = stopTimes[position - 1];
+            if (previousStopTime != null && previousStopTime.departure() > stopTime.arrival()) {
+                throw new IllegalArgumentException(
+                        "Departure time at previous stop is greater than arrival time at current stop.");
+            }
+        }
+
+        if (position < stopTimes.length - 1) {
+            StopTime nextStopTime = stopTimes[position + 1];
+            if (nextStopTime != null && stopTime.departure() > nextStopTime.arrival()) {
+                throw new IllegalArgumentException(
+                        "Departure time at current stop is greater than arrival time at next stop.");
+            }
+        }
+
+        stopTimes[position] = stopTime;
+    }
+
+    private void validate() {
+        for (Map.Entry<String, StopTime[]> trip : trips.entrySet()) {
+            StopTime[] stopTimes = trip.getValue();
+            for (Map.Entry<Integer, String> stop : stopSequence.entrySet()) {
+                // ensure all stop times are set and therefore all trips must have the same stops
+                if (stopTimes[stop.getKey()] == null) {
+                    throw new IllegalStateException(
+                            "Stop time at stop " + stop.getKey() + " on trip " + trip.getKey() + " not set.");
+                }
+            }
+        }
+    }
+
+    RouteContainer build() {
+        log.debug("Validating and building route {}", routeId);
+        validate();
+
+        // sort trips by the departure time of the first stop
+        List<Map.Entry<String, StopTime[]>> sortedEntries = new ArrayList<>(trips.entrySet());
+        sortedEntries.sort(Comparator.comparingInt(entry -> entry.getValue()[0].departure()));
+
+        // populate sortedTrips in the same order as sortedEntries, LinkedHashMap stores insertion order
+        LinkedHashMap<String, StopTime[]> sortedTrips = new LinkedHashMap<>(sortedEntries.size());
+        for (Map.Entry<String, StopTime[]> entry : sortedEntries) {
+            sortedTrips.put(entry.getKey(), entry.getValue());
+        }
+
+        return new RouteContainer(routeId, stopSequence, sortedTrips);
+    }
+
+    record RouteContainer(String id, Map<Integer, String> stopSequence,
+                          LinkedHashMap<String, StopTime[]> trips) implements Comparable<RouteContainer> {
+
+        @Override
+        public int compareTo(@NotNull RouteContainer o) {
+            StopTime thisFirstStopTime = this.trips.values().iterator().next()[0];
+            StopTime otherFirstStopTime = o.trips.values().iterator().next()[0];
+            return Integer.compare(thisFirstStopTime.departure(), otherFirstStopTime.departure());
+        }
+
+    }
+}
+
+

--- a/src/main/java/ch/naviqore/raptor/simple/RouteScanner.java
+++ b/src/main/java/ch/naviqore/raptor/simple/RouteScanner.java
@@ -1,0 +1,264 @@
+package ch.naviqore.raptor.simple;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static ch.naviqore.raptor.simple.StopLabelsAndTimes.INFINITY;
+
+/**
+ * Scans routes, which are passing marked stops, for each round.
+ */
+@Slf4j
+class RouteScanner {
+
+    private final Stop[] stops;
+    private final int[] stopRoutes;
+    private final StopTime[] stopTimes;
+    private final Route[] routes;
+    private final RouteStop[] routeStops;
+
+    private final StopLabelsAndTimes stopLabelsAndTimes;
+
+    /**
+     * the minimum transfer duration time, since this is intended as rest period it is added to the walk time.
+     */
+    private final int minTransferDuration;
+
+    /**
+     * @param stopLabelsAndTimes      the best time per stop and label per stop and round.
+     * @param raptorData              the current raptor data structures.
+     * @param minimumTransferDuration The minimum transfer duration time.
+     */
+    RouteScanner(StopLabelsAndTimes stopLabelsAndTimes, RaptorData raptorData, int minimumTransferDuration) {
+        // constant data structures
+        this.stops = raptorData.getStopContext().stops();
+        this.stopRoutes = raptorData.getStopContext().stopRoutes();
+        this.stopTimes = raptorData.getRouteTraversal().stopTimes();
+        this.routes = raptorData.getRouteTraversal().routes();
+        this.routeStops = raptorData.getRouteTraversal().routeStops();
+        // note: will also change outside of scanner, due to footpath relaxation
+        this.stopLabelsAndTimes = stopLabelsAndTimes;
+        // constant configuration of scanner
+        this.minTransferDuration = minimumTransferDuration;
+    }
+
+    /**
+     * Scans all routes passing marked stops for the given round.
+     *
+     * @param round       the current round.
+     * @param markedStops the marked stops for this round.
+     * @return the marked stops for the next round.
+     */
+    Set<Integer> scan(int round, Set<Integer> markedStops) {
+        Set<Integer> routesToScan = getRoutesToScan(markedStops);
+        log.debug("Scanning routes for round {} ({})", round, routesToScan);
+
+        // scan selected routes and mark stops with improved times
+        Set<Integer> markedStopsNext = new HashSet<>();
+        for (int currentRouteIdx : routesToScan) {
+            scanRoute(currentRouteIdx, round, markedStops, markedStopsNext);
+        }
+
+        return markedStopsNext;
+    }
+
+    /**
+     * Get all routes to scan from the marked stops.
+     *
+     * @param markedStops the set of marked stops from the previous round.
+     */
+    private Set<Integer> getRoutesToScan(Set<Integer> markedStops) {
+        Set<Integer> routesToScan = new HashSet<>();
+        for (int stopIdx : markedStops) {
+            Stop currentStop = stops[stopIdx];
+            int stopRouteIdx = currentStop.stopRouteIdx();
+            int stopRouteEndIdx = stopRouteIdx + currentStop.numberOfRoutes();
+            while (stopRouteIdx < stopRouteEndIdx) {
+                routesToScan.add(stopRoutes[stopRouteIdx]);
+                stopRouteIdx++;
+            }
+        }
+        return routesToScan;
+    }
+
+    /**
+     * Scan a route in time type applicable direction to find the best times for each stop on route for given round.
+     *
+     * @param currentRouteIdx the index of the current route.
+     * @param round           the current round.
+     * @param markedStops     the set of marked stops from the previous round.
+     * @param markedStopsNext the set of marked stops for the next round.
+     */
+    private void scanRoute(int currentRouteIdx, int round, Set<Integer> markedStops, Set<Integer> markedStopsNext) {
+
+        final int lastRound = round - 1;
+
+        Route currentRoute = routes[currentRouteIdx];
+        log.debug("Scanning route {}", currentRoute.id());
+        final int firstRouteStopIdx = currentRoute.firstRouteStopIdx();
+        final int firstStopTimeIdx = currentRoute.firstStopTimeIdx();
+        final int numberOfStops = currentRoute.numberOfStops();
+
+        ActiveTrip activeTrip = null;
+
+        for (int stopOffset = 0; stopOffset != numberOfStops; stopOffset++) {
+            int stopIdx = routeStops[firstRouteStopIdx + stopOffset].stopIndex();
+            Stop stop = stops[stopIdx];
+            int bestStopTime = stopLabelsAndTimes.getComparableBestTime(stopIdx);
+
+            // find first marked stop in route
+            if (activeTrip == null) {
+                if (!canEnterAtStop(stop, bestStopTime, markedStops, stopIdx, stopOffset, numberOfStops)) {
+                    continue;
+                }
+            } else {
+                // in this case we are on a trip and need to check if time has improved
+                StopTime stopTimeObj = stopTimes[firstStopTimeIdx + activeTrip.tripOffset * numberOfStops + stopOffset];
+                if (!checkIfTripIsPossibleAndUpdateMarks(stopTimeObj, activeTrip, stop, bestStopTime, stopIdx, round,
+                        lastRound, markedStopsNext, currentRouteIdx)) {
+                    continue;
+                }
+            }
+            activeTrip = findPossibleTrip(stopIdx, stop, stopOffset, currentRoute, lastRound);
+        }
+    }
+
+    /**
+     * This method checks if a trip can be entered at the stop in the current round. A trip can be entered if the stop
+     * was reached in a previous round, and is not the first (targetTime) / last (sourceTime) stop of a trip or (for
+     * performance reasons) assuming that this check is only run when not travelling with an active trip, the stop was
+     * not marked in a previous round (i.e., the lasts round trip query would be repeated).
+     *
+     * @param stop          the stop to check if a trip can be entered.
+     * @param stopTime      the time at the stop.
+     * @param markedStops   the set of marked stops from the previous round.
+     * @param stopIdx       the index of the stop to check if a trip can be entered.
+     * @param stopOffset    the offset of the stop in the route.
+     * @param numberOfStops the number of stops in the route.
+     */
+    private boolean canEnterAtStop(Stop stop, int stopTime, Set<Integer> markedStops, int stopIdx, int stopOffset,
+                                   int numberOfStops) {
+
+        if (stopTime == INFINITY) {
+            log.debug("Stop {} cannot be reached, continue", stop.id());
+            return false;
+        }
+
+        if (!markedStops.contains(stopIdx)) {
+            // this stop has already been scanned in previous round without improved target time
+            log.debug("Stop {} was not improved in previous round, continue", stop.id());
+            return false;
+        }
+
+        if (stopOffset + 1 == numberOfStops) {
+            // last stop in route, does not make sense to check for trip to enter
+            log.debug("Stop {} is last stop in route, continue", stop.id());
+            return false;
+        }
+
+        // got first marked stop in the route
+        log.debug("Got first entry point at stop {} at {}", stop.id(), stopTime);
+
+        return true;
+    }
+
+    /**
+     * <p>This method checks if the time at a stop can be improved by arriving or departing with the active trip, if so
+     * the stop is marked for the next round and the time is updated. If the time is improved it is clear that an
+     * earlier or later trip (based on the TimeType) is not possible and the method returns false.</p>
+     * <p>If the time was not improved, an additional check will be needed to figure out if an earlier or later trip
+     * from the stop is possible within the current round, thus the method returns true.</p>
+     *
+     * @param stopTime        the stop time to check for an earlier or later trip.
+     * @param activeTrip      the active trip to check for an earlier or later trip.
+     * @param stop            the stop to check for an earlier or later trip.
+     * @param bestStopTime    the earliest or latest time at the stop based on the TimeType.
+     * @param stopIdx         the index of the stop to check for an earlier or later trip.
+     * @param markedStopsNext the set of marked stops for the next round.
+     * @param currentRouteIdx the index of the current route.
+     * @return true if an earlier or later trip is possible, false otherwise.
+     */
+    private boolean checkIfTripIsPossibleAndUpdateMarks(StopTime stopTime, ActiveTrip activeTrip, Stop stop,
+                                                        int bestStopTime, int stopIdx, int thisRound, int lastRound,
+                                                        Set<Integer> markedStopsNext, int currentRouteIdx) {
+
+        boolean isImproved = stopTime.arrival() < bestStopTime;
+
+        if (isImproved) {
+            log.debug("Stop {} was improved", stop.id());
+            stopLabelsAndTimes.setBestTime(stopIdx, stopTime.arrival());
+
+            StopLabelsAndTimes.Label label = new StopLabelsAndTimes.Label(activeTrip.entryTime(), stopTime.arrival(),
+                    StopLabelsAndTimes.LabelType.ROUTE, currentRouteIdx, activeTrip.tripOffset, stopIdx,
+                    activeTrip.previousLabel);
+            stopLabelsAndTimes.setLabel(thisRound, stopIdx, label);
+            markedStopsNext.add(stopIdx);
+
+            return false;
+        } else {
+            log.debug("Stop {} was not improved", stop.id());
+            StopLabelsAndTimes.Label previous = stopLabelsAndTimes.getLabel(lastRound, stopIdx);
+
+            boolean isImprovedInSameRound = previous == null || previous.targetTime() >= stopTime.arrival();
+            if (isImprovedInSameRound) {
+                log.debug("Stop {} has been improved in same round, trip not possible within this round", stop.id());
+                return false;
+            } else {
+                log.debug("Checking for trips at stop {}", stop.id());
+                return true;
+            }
+        }
+    }
+
+    /**
+     * Find the possible trip on the route. This loops through all trips departing or arriving from a given stop for a
+     * given route and returns details about the first or last trip that can be taken (departing after or arriving
+     * before the time of the previous round at this stop and accounting for transfer constraints).
+     *
+     * @param stopIdx    the index of the stop to find the possible trip from.
+     * @param stop       the stop to find the possible trip from.
+     * @param stopOffset the offset of the stop in the route.
+     * @param route      the route to find the possible trip on.
+     * @param lastRound  the last round.
+     */
+    private @Nullable ActiveTrip findPossibleTrip(int stopIdx, Stop stop, int stopOffset, Route route, int lastRound) {
+
+        int firstStopTimeIdx = route.firstStopTimeIdx();
+        int numberOfStops = route.numberOfStops();
+        int numberOfTrips = route.numberOfTrips();
+
+        int tripOffset = 0;
+        int entryTime = 0;
+        StopLabelsAndTimes.Label previousLabel = stopLabelsAndTimes.getLabel(lastRound, stopIdx);
+
+        // this is the reference time, where we can depart after or arrive earlier
+        int referenceTime = previousLabel.targetTime();
+        if (previousLabel.type() == StopLabelsAndTimes.LabelType.ROUTE) {
+            referenceTime += Math.max(stop.sameStopTransferTime(), minTransferDuration);
+        }
+
+        while (tripOffset < numberOfTrips) {
+            StopTime currentStopTime = stopTimes[firstStopTimeIdx + tripOffset * numberOfStops + stopOffset];
+            if (currentStopTime.departure() >= referenceTime) {
+                log.debug("Found active trip ({}) on route {}", tripOffset, route.id());
+                entryTime = currentStopTime.departure();
+                break;
+            }
+            if (tripOffset < numberOfTrips - 1) {
+                tripOffset++;
+            } else {
+                // no active trip found
+                log.debug("No active trip found on route {}", route.id());
+                return null;
+            }
+        }
+
+        return new ActiveTrip(tripOffset, entryTime, previousLabel);
+    }
+
+    private record ActiveTrip(int tripOffset, int entryTime, StopLabelsAndTimes.Label previousLabel) {
+    }
+}

--- a/src/main/java/ch/naviqore/raptor/simple/RouteStop.java
+++ b/src/main/java/ch/naviqore/raptor/simple/RouteStop.java
@@ -1,0 +1,4 @@
+package ch.naviqore.raptor.simple;
+
+record RouteStop(int stopIndex, int routeIndex) {
+}

--- a/src/main/java/ch/naviqore/raptor/simple/RouteTraversal.java
+++ b/src/main/java/ch/naviqore/raptor/simple/RouteTraversal.java
@@ -1,0 +1,11 @@
+package ch.naviqore.raptor.simple;
+
+/**
+ * Memory optimized itinerant data structure for efficient route traversal
+ *
+ * @param stopTimes  stop times
+ * @param routes     routes
+ * @param routeStops route stops
+ */
+record RouteTraversal(StopTime[] stopTimes, Route[] routes, RouteStop[] routeStops) {
+}

--- a/src/main/java/ch/naviqore/raptor/simple/SimpleRaptorRouter.java
+++ b/src/main/java/ch/naviqore/raptor/simple/SimpleRaptorRouter.java
@@ -18,7 +18,7 @@ import java.util.*;
  * Raptor algorithm implementation
  */
 @Slf4j
-class SimpleRaptorRouter implements RaptorAlgorithm, RaptorData {
+public class SimpleRaptorRouter implements RaptorAlgorithm, RaptorData {
 
     @Getter
     private final Lookup lookup;
@@ -36,6 +36,10 @@ class SimpleRaptorRouter implements RaptorAlgorithm, RaptorData {
         this.stopContext = stopContext;
         this.routeTraversal = routeTraversal;
         validator = new InputValidator(lookup.stops());
+    }
+
+    public static RaptorRouterBuilder builder(int defaultSameStopTransferTime) {
+        return new RaptorRouterBuilder(defaultSameStopTransferTime);
     }
 
     @Override

--- a/src/main/java/ch/naviqore/raptor/simple/SimpleRaptorRouter.java
+++ b/src/main/java/ch/naviqore/raptor/simple/SimpleRaptorRouter.java
@@ -114,8 +114,8 @@ public class SimpleRaptorRouter implements RaptorAlgorithm, RaptorData {
         List<StopLabelsAndTimes.Label[]> bestLabelsPerRound = new Query(this, sourceStopIndices, targetStopIndices,
                 sourceTimes, walkingDurationsToTarget, config).run();
 
-        return new LabelPostprocessor(this).reconstructParetoOptimalSolutions(bestLabelsPerRound,
-                validatedTargetStops, referenceDate);
+        return new LabelPostprocessor(this).reconstructParetoOptimalSolutions(bestLabelsPerRound, validatedTargetStops,
+                referenceDate);
     }
 
     /**

--- a/src/main/java/ch/naviqore/raptor/simple/SimpleRaptorRouter.java
+++ b/src/main/java/ch/naviqore/raptor/simple/SimpleRaptorRouter.java
@@ -1,0 +1,202 @@
+package ch.naviqore.raptor.simple;
+
+import ch.naviqore.raptor.Connection;
+import ch.naviqore.raptor.QueryConfig;
+import ch.naviqore.raptor.RaptorAlgorithm;
+import ch.naviqore.raptor.TimeType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.NotImplementedException;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+
+/**
+ * Raptor algorithm implementation
+ */
+@Slf4j
+class SimpleRaptorRouter implements RaptorAlgorithm, RaptorData {
+
+    @Getter
+    private final Lookup lookup;
+
+    @Getter
+    private final StopContext stopContext;
+
+    @Getter
+    private final RouteTraversal routeTraversal;
+
+    private final InputValidator validator;
+
+    SimpleRaptorRouter(Lookup lookup, StopContext stopContext, RouteTraversal routeTraversal) {
+        this.lookup = lookup;
+        this.stopContext = stopContext;
+        this.routeTraversal = routeTraversal;
+        validator = new InputValidator(lookup.stops());
+    }
+
+    @Override
+    public List<Connection> routeEarliestArrival(Map<String, LocalDateTime> departureStops,
+                                                 Map<String, Integer> arrivalStops, QueryConfig config) {
+        InputValidator.checkNonNullOrEmptyStops(departureStops, "Departure");
+        InputValidator.checkNonNullOrEmptyStops(arrivalStops, "Arrival");
+
+        log.info("Routing earliest arrival from {} to {} departing at {}", departureStops.keySet(),
+                arrivalStops.keySet(), departureStops.values().stream().toList());
+
+        return getConnections(departureStops, arrivalStops, config);
+    }
+
+    @Override
+    public List<Connection> routeLatestDeparture(Map<String, Integer> departureStops,
+                                                 Map<String, LocalDateTime> arrivalStops, QueryConfig config) {
+        throw new NotImplementedException("Latest departure not implemented.");
+    }
+
+    @Override
+    public Map<String, Connection> routeIsolines(Map<String, LocalDateTime> sourceStops, TimeType timeType,
+                                                 QueryConfig config) {
+        if (timeType == TimeType.ARRIVAL) {
+            throw new NotImplementedException("Arrival isolines not implemented.");
+        }
+        InputValidator.checkNonNullOrEmptyStops(sourceStops, "Source");
+        InputValidator.validateSourceStopTimes(sourceStops);
+
+        log.info("Routing isolines from {} with {}", sourceStops.keySet(), timeType);
+        LocalDate referenceDate = DateTimeUtils.getReferenceDate(sourceStops);
+        Map<Integer, Integer> validatedSourceStopIdx = validator.validateStopsAndGetIndices(
+                DateTimeUtils.mapLocalDateTimeToTimestamp(sourceStops, referenceDate));
+
+        int[] sourceStopIndices = validatedSourceStopIdx.keySet().stream().mapToInt(Integer::intValue).toArray();
+        int[] refStopTimes = validatedSourceStopIdx.values().stream().mapToInt(Integer::intValue).toArray();
+        List<StopLabelsAndTimes.Label[]> bestLabelsPerRound = new Query(this, sourceStopIndices, new int[]{},
+                refStopTimes, new int[]{}, config).run();
+
+        return new LabelPostprocessor(this).reconstructIsolines(bestLabelsPerRound, referenceDate);
+    }
+
+    /**
+     * This is the main method to route from source to target stops. The method will spawn from the source stops and
+     * expand footpaths and routes until the target stops are reached. The method will return the pareto-optimal
+     * connections.
+     * <p>
+     * Note, in case the time type is arrival, the source stop is the arrival stop (last stop of the connection) and the
+     * route is calculated backwards in time, searching for the latest possible departure at the departure stop (target
+     * stops).
+     *
+     * @param sourceStops is a map of stop ids and departure/arrival times depending on the time type
+     * @param targetStops is a map of stop ids and walking durations to target stops
+     * @param config      is the query configuration
+     * @return a list of pareto-optimal connections
+     */
+    private List<Connection> getConnections(Map<String, LocalDateTime> sourceStops, Map<String, Integer> targetStops,
+                                            QueryConfig config) {
+        InputValidator.validateSourceStopTimes(sourceStops);
+        LocalDate referenceDate = DateTimeUtils.getReferenceDate(sourceStops);
+        Map<String, Integer> sourceStopsSecondsOfDay = DateTimeUtils.mapLocalDateTimeToTimestamp(sourceStops,
+                referenceDate);
+        Map<Integer, Integer> validatedSourceStops = validator.validateStopsAndGetIndices(sourceStopsSecondsOfDay);
+        Map<Integer, Integer> validatedTargetStops = validator.validateStopsAndGetIndices(targetStops);
+        InputValidator.validateStopPermutations(sourceStopsSecondsOfDay, targetStops);
+
+        int[] sourceStopIndices = validatedSourceStops.keySet().stream().mapToInt(Integer::intValue).toArray();
+        int[] sourceTimes = validatedSourceStops.values().stream().mapToInt(Integer::intValue).toArray();
+        int[] targetStopIndices = validatedTargetStops.keySet().stream().mapToInt(Integer::intValue).toArray();
+        int[] walkingDurationsToTarget = validatedTargetStops.values().stream().mapToInt(Integer::intValue).toArray();
+
+        List<StopLabelsAndTimes.Label[]> bestLabelsPerRound = new Query(this, sourceStopIndices, targetStopIndices,
+                sourceTimes, walkingDurationsToTarget, config).run();
+
+        return new LabelPostprocessor(this).reconstructParetoOptimalSolutions(bestLabelsPerRound,
+                validatedTargetStops, referenceDate);
+    }
+
+    /**
+     * Validate inputs to raptor.
+     */
+    @RequiredArgsConstructor
+    private static class InputValidator {
+        private static final int MIN_WALKING_TIME_TO_TARGET = 0;
+        private static final int MAX_DIFFERENCE_IN_SOURCE_STOP_TIMES = 24 * 60 * 60;
+
+        private final Map<String, Integer> stopsToIdx;
+
+        private static void checkNonNullOrEmptyStops(Map<String, ?> stops, String labelSource) {
+            if (stops == null) {
+                throw new IllegalArgumentException(String.format("%s stops must not be null.", labelSource));
+            }
+            if (stops.isEmpty()) {
+                throw new IllegalArgumentException(String.format("%s stops must not be empty.", labelSource));
+            }
+        }
+
+        private static void validateSourceStopTimes(Map<String, LocalDateTime> sourceStops) {
+            // check that no null values are present
+            if (sourceStops.values().stream().anyMatch(Objects::isNull)) {
+                throw new IllegalArgumentException("Source stop times must not be null.");
+            }
+
+            // get min and max values
+            LocalDateTime min = sourceStops.values().stream().min(LocalDateTime::compareTo).orElseThrow();
+            LocalDateTime max = sourceStops.values().stream().max(LocalDateTime::compareTo).orElseThrow();
+            if (Duration.between(min, max).getSeconds() > MAX_DIFFERENCE_IN_SOURCE_STOP_TIMES) {
+                throw new IllegalArgumentException("Difference between source stop times must be less than 24 hours.");
+            }
+        }
+
+        private static void validateStopPermutations(Map<String, Integer> sourceStops,
+                                                     Map<String, Integer> targetStops) {
+            targetStops.values().forEach(InputValidator::validateWalkingTimeToTarget);
+
+            // ensure departure and arrival stops are not the same
+            if (!Collections.disjoint(sourceStops.keySet(), targetStops.keySet())) {
+                throw new IllegalArgumentException("Source and target stop IDs must not be the same.");
+            }
+        }
+
+        private static void validateWalkingTimeToTarget(int walkingDurationToTarget) {
+            if (walkingDurationToTarget < MIN_WALKING_TIME_TO_TARGET) {
+                throw new IllegalArgumentException(
+                        "Walking duration to target must be greater or equal to " + MIN_WALKING_TIME_TO_TARGET + "seconds.");
+            }
+        }
+
+        /**
+         * Validate the stops provided in the query. This method will check that the map of stop ids and their
+         * corresponding departure / walk to target times are valid. This is done by checking if the map is not empty
+         * and then checking each entry if the stop id is present in the lookup. If not it is removed from the query. If
+         * no valid stops are found an IllegalArgumentException is thrown.
+         *
+         * @param stops the stops to validate.
+         * @return a map of valid stop IDs and their corresponding departure / walk to target times.
+         */
+        private Map<Integer, Integer> validateStopsAndGetIndices(Map<String, Integer> stops) {
+            if (stops.isEmpty()) {
+                throw new IllegalArgumentException("At least one stop ID must be provided.");
+            }
+
+            // loop over all stop pairs and check if stop exists in raptor, then validate departure time
+            Map<Integer, Integer> validStopIds = new HashMap<>();
+            for (Map.Entry<String, Integer> entry : stops.entrySet()) {
+                String stopId = entry.getKey();
+                int time = entry.getValue();
+
+                if (stopsToIdx.containsKey(stopId)) {
+                    validStopIds.put(stopsToIdx.get(stopId), time);
+                } else {
+                    log.warn("Stop ID {} not found in lookup removing from query.", entry.getKey());
+                }
+            }
+
+            if (validStopIds.isEmpty()) {
+                throw new IllegalArgumentException("No valid stops provided.");
+            }
+
+            return validStopIds;
+        }
+    }
+
+}

--- a/src/main/java/ch/naviqore/raptor/simple/Stop.java
+++ b/src/main/java/ch/naviqore/raptor/simple/Stop.java
@@ -1,0 +1,5 @@
+package ch.naviqore.raptor.simple;
+
+record Stop(String id, int stopRouteIdx, int numberOfRoutes, int sameStopTransferTime, int transferIdx,
+            int numberOfTransfers) {
+}

--- a/src/main/java/ch/naviqore/raptor/simple/StopContext.java
+++ b/src/main/java/ch/naviqore/raptor/simple/StopContext.java
@@ -1,0 +1,4 @@
+package ch.naviqore.raptor.simple;
+
+record StopContext(Transfer[] transfers, Stop[] stops, int[] stopRoutes) {
+}

--- a/src/main/java/ch/naviqore/raptor/simple/StopLabelsAndTimes.java
+++ b/src/main/java/ch/naviqore/raptor/simple/StopLabelsAndTimes.java
@@ -28,7 +28,7 @@ final class StopLabelsAndTimes {
 
         // set best times to initial value
         bestTimeForStops = new int[stopSize];
-        Arrays.fill(bestTimeForStops,INFINITY);
+        Arrays.fill(bestTimeForStops, INFINITY);
 
         // set empty labels for first round
         addNewRound();

--- a/src/main/java/ch/naviqore/raptor/simple/StopLabelsAndTimes.java
+++ b/src/main/java/ch/naviqore/raptor/simple/StopLabelsAndTimes.java
@@ -1,0 +1,127 @@
+package ch.naviqore.raptor.simple;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This object stores the current best labels and times of the raptor routing algorithm for a query instance.
+ */
+final class StopLabelsAndTimes {
+
+    public final static int INFINITY = Integer.MAX_VALUE;
+    public final static int NO_INDEX = -1;
+
+    // the best labels per stop and round
+    private final List<Label[]> bestLabelsPerRound = new ArrayList<>();
+
+    // the global best time per stop
+    private final int[] bestTimeForStops;
+
+    private final int stopSize;
+
+    StopLabelsAndTimes(int stopSize) {
+        this.stopSize = stopSize;
+
+        // set best times to initial value
+        bestTimeForStops = new int[stopSize];
+        Arrays.fill(bestTimeForStops,INFINITY);
+
+        // set empty labels for first round
+        addNewRound();
+    }
+
+    /**
+     * Adds a new round with empty labels.
+     */
+    void addNewRound() {
+        bestLabelsPerRound.add(new Label[stopSize]);
+    }
+
+    Label getLabel(int round, int stopIdx) {
+        return bestLabelsPerRound.get(round)[stopIdx];
+    }
+
+    /**
+     * Sets a new label for a stop and round.
+     */
+    void setLabel(int round, int stopIdx, Label label) {
+        bestLabelsPerRound.get(round)[stopIdx] = label;
+    }
+
+    /**
+     * Get global best time of a stop for comparison. The comparison of arrival/departures requires that the same stop
+     * transfer time is subtracted (departure) or added (arrival) to the actual target time, so that the comparison is
+     * correct with route target times.
+     */
+    int getComparableBestTime(int stopIdx) {
+        return bestTimeForStops[stopIdx];
+    }
+
+    /**
+     * Get the actual best time of a stop. This is the actual target time. This should not be used to compare times of
+     * different label types (transfer vs. route), as the same stop transfer time is not considered.
+     */
+    int getActualBestTime(int stopIdx) {
+        for (int i = bestLabelsPerRound.size() - 1; i >= 0; i--) {
+            Label label = bestLabelsPerRound.get(i)[stopIdx];
+            if (label != null) {
+                return label.targetTime;
+            }
+        }
+
+        return INFINITY;
+    }
+
+    /**
+     * Set the global best time for a stop.
+     */
+    void setBestTime(int stopIdx, int time) {
+        bestTimeForStops[stopIdx] = time;
+    }
+
+    /**
+     * Return the result as unmodifiable list, since it should only be modified via the setter and getter methods.
+     */
+    List<Label[]> getBestLabelsPerRound() {
+        return Collections.unmodifiableList(bestLabelsPerRound);
+    }
+
+    /**
+     * Arrival type of the label.
+     */
+    enum LabelType {
+
+        /**
+         * First label in the connection, so there is no previous label set.
+         */
+        INITIAL,
+        /**
+         * A route label uses a public transit trip in the network.
+         */
+        ROUTE,
+        /**
+         * Uses a transfer between stops (not a same stop transfer).
+         */
+        TRANSFER
+
+    }
+
+    /**
+     * A label is a part of a connection in the same mode (PT or walk).
+     *
+     * @param sourceTime         the source time of the label in seconds after midnight.
+     * @param targetTime         the target time of the label in seconds after midnight.
+     * @param type               the type of the label, can be INITIAL, ROUTE or TRANSFER.
+     * @param routeOrTransferIdx the index of the route or of the transfer, see arrival type (or NO_INDEX).
+     * @param tripOffset         the trip offset on the current route (or NO_INDEX).
+     * @param stopIdx            the target stop of the label.
+     * @param previous           the previous label, null if it is the initial label.
+     */
+    record Label(int sourceTime, int targetTime, LabelType type, int routeOrTransferIdx, int tripOffset, int stopIdx,
+                 @Nullable Label previous) {
+    }
+}

--- a/src/main/java/ch/naviqore/raptor/simple/StopTime.java
+++ b/src/main/java/ch/naviqore/raptor/simple/StopTime.java
@@ -1,0 +1,11 @@
+package ch.naviqore.raptor.simple;
+
+record StopTime(int arrival, int departure) {
+
+    public StopTime {
+        if (arrival > departure) {
+            throw new IllegalArgumentException("Arrival time must be before departure time.");
+        }
+    }
+
+}

--- a/src/main/java/ch/naviqore/raptor/simple/Transfer.java
+++ b/src/main/java/ch/naviqore/raptor/simple/Transfer.java
@@ -1,0 +1,4 @@
+package ch.naviqore.raptor.simple;
+
+record Transfer(int targetStopIdx, int duration) {
+}

--- a/src/main/java/ch/naviqore/raptor/simple/gtfs/Converter.java
+++ b/src/main/java/ch/naviqore/raptor/simple/gtfs/Converter.java
@@ -1,0 +1,96 @@
+package ch.naviqore.raptor.simple.gtfs;
+
+import ch.naviqore.gtfs.schedule.model.*;
+import ch.naviqore.gtfs.schedule.type.TransferType;
+import ch.naviqore.raptor.RaptorAlgorithm;
+import ch.naviqore.raptor.simple.RaptorRouterBuilder;
+import ch.naviqore.raptor.simple.SimpleRaptorRouter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Maps GTFS schedule to Raptor
+ * <p>
+ * For each sub-route in a GTFS route a route in Raptor is created. Only the "minimum time" transfers between different
+ * stops are considered as Raptor transfers. In the Raptor model, transfers are treated exclusively as pedestrian paths
+ * between stops, reflecting necessary walking connections. Thus, other types of GTFS transfers are omitted from the
+ * mapping process to align with Raptor's conceptual model.
+ */
+@Slf4j
+public class Converter {
+
+    private final Set<RoutePartitioner.SubRoute> addedSubRoutes = new HashSet<>();
+    private final Set<String> addedStops = new HashSet<>();
+    private final RaptorRouterBuilder builder;
+    private final RoutePartitioner partitioner;
+    private final GtfsSchedule schedule;
+
+    public Converter(GtfsSchedule schedule, int sameStopTransferTime) {
+        this.partitioner = new RoutePartitioner(schedule);
+        this.schedule = schedule;
+        this.builder = SimpleRaptorRouter.builder(sameStopTransferTime);
+    }
+
+    public RaptorAlgorithm convert(LocalDate date) {
+        List<Trip> activeTrips = schedule.getActiveTrips(date);
+        log.info("Converting {} active trips from GTFS schedule to Raptor model", activeTrips.size());
+
+        for (Trip trip : activeTrips) {
+            RoutePartitioner.SubRoute subRoute = partitioner.getSubRoute(trip);
+
+            // add route if not already
+            if (!addedSubRoutes.contains(subRoute)) {
+                List<String> stopIds = subRoute.getStopsSequence().stream().map(Stop::getId).toList();
+
+                // add stops of that are not already added
+                for (String stopId : stopIds) {
+                    if (!addedStops.contains(stopId)) {
+                        builder.addStop(stopId);
+                        addedStops.add(stopId);
+                    }
+                }
+
+                builder.addRoute(subRoute.getId(), stopIds);
+                addedSubRoutes.add(subRoute);
+            }
+
+            // add current trip
+            builder.addTrip(trip.getId(), subRoute.getId());
+            List<StopTime> stopTimes = trip.getStopTimes();
+            for (int i = 0; i < stopTimes.size(); i++) {
+                StopTime stopTime = stopTimes.get(i);
+                builder.addStopTime(subRoute.getId(), trip.getId(), i, stopTime.stop().getId(),
+                        stopTime.arrival().getTotalSeconds(), stopTime.departure().getTotalSeconds());
+            }
+        }
+
+        addTransfers();
+
+        return builder.build();
+    }
+
+    private void addTransfers() {
+        for (String stopId : addedStops) {
+            Stop stop = schedule.getStops().get(stopId);
+            for (Transfer transfer : stop.getTransfers()) {
+                if (transfer.getTransferType() == TransferType.MINIMUM_TIME && transfer.getMinTransferTime()
+                        .isPresent()) {
+                    try {
+                        builder.addTransfer(stop.getId(), transfer.getToStop().getId(),
+                                transfer.getMinTransferTime().get());
+                    } catch (IllegalArgumentException e) {
+                        // TODO: Problem is that with active trips we already filtered some stops which have no active
+                        //  trip anymore, so they are not added. Maybe we should build the Raptor always for the
+                        //  complete schedule, and add use masking array for the stop times of when we want to create
+                        //  routes at a specific date. This would also be more efficient.
+                        log.debug("Omit adding transfer: {}", e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/ch/naviqore/raptor/simple/gtfs/RoutePartitioner.java
+++ b/src/main/java/ch/naviqore/raptor/simple/gtfs/RoutePartitioner.java
@@ -1,0 +1,106 @@
+package ch.naviqore.raptor.simple.gtfs;
+
+import ch.naviqore.gtfs.schedule.model.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Splits the routes of a GTFS schedule into sub-routes. In a GTFS schedule, a route can have multiple trips with
+ * different stop sequences. This class groups trips with the same stop sequence into sub-routes and assigns them the
+ * parent route.
+ */
+@Slf4j
+public class RoutePartitioner {
+    private final Map<Route, Map<String, SubRoute>> subRoutes = new HashMap<>();
+
+    public RoutePartitioner(GtfsSchedule schedule) {
+        log.info("Partitioning GTFS schedule with {} routes into sub-routes", schedule.getRoutes().size());
+        schedule.getRoutes().values().forEach(this::processRoute);
+        log.info("Got {} sub-routes in schedule", subRoutes.values().stream().mapToInt(Map::size).sum());
+    }
+
+    private void processRoute(Route route) {
+        Map<String, SubRoute> sequenceKeyToSubRoute = new HashMap<>();
+        route.getTrips().forEach(trip -> {
+            String key = generateStopSequenceKey(trip);
+            SubRoute subRoute = sequenceKeyToSubRoute.computeIfAbsent(key,
+                    s -> new SubRoute(String.format("%s_sr%d", route.getId(), sequenceKeyToSubRoute.size() + 1), route,
+                            key, extractStopSequence(trip)));
+            subRoute.addTrip(trip);
+        });
+        subRoutes.put(route, sequenceKeyToSubRoute);
+        log.debug("Route {} split into {} sub-routes", route.getId(), sequenceKeyToSubRoute.size());
+    }
+
+    private String generateStopSequenceKey(Trip trip) {
+        return trip.getStopTimes().stream().map(t -> t.stop().getId()).collect(Collectors.joining("-"));
+    }
+
+    private List<Stop> extractStopSequence(Trip trip) {
+        List<Stop> sequence = new ArrayList<>();
+        for (StopTime stopTime : trip.getStopTimes()) {
+            sequence.add(stopTime.stop());
+        }
+
+        return sequence;
+    }
+
+    public List<SubRoute> getSubRoutes(Route route) {
+        Map<String, SubRoute> currentSubRoutes = subRoutes.get(route);
+        if (currentSubRoutes == null) {
+            throw new IllegalArgumentException("Route " + route.getId() + " not found in schedule");
+        }
+
+        return new ArrayList<>(currentSubRoutes.values());
+    }
+
+    public SubRoute getSubRoute(Trip trip) {
+        Map<String, SubRoute> currentSubRoutes = subRoutes.get(trip.getRoute());
+        if (currentSubRoutes == null) {
+            throw new IllegalArgumentException("Trip " + trip.getId() + " not found in schedule");
+        }
+        String key = generateStopSequenceKey(trip);
+
+        return currentSubRoutes.get(key);
+    }
+
+    /**
+     * A sub-route belongs to a route, but has a unique stop sequence.
+     */
+    @RequiredArgsConstructor
+    @Getter
+    public static class SubRoute {
+        private final String id;
+        private final Route route;
+        @Getter(AccessLevel.NONE)
+        private final String stopSequenceKey;
+        private final List<Stop> stopsSequence;
+        private final List<Trip> trips = new ArrayList<>();
+
+        private void addTrip(Trip trip) {
+            trips.add(trip);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (SubRoute) obj;
+            return Objects.equals(this.id, that.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id);
+        }
+
+        public String toString() {
+            return "SubRoute[" + "id=" + id + ", " + "route=" + route + ", " + "stopSequence=" + stopSequenceKey + ']';
+        }
+    }
+}

--- a/src/main/java/ch/naviqore/raptor/simple/readme.md
+++ b/src/main/java/ch/naviqore/raptor/simple/readme.md
@@ -1,0 +1,9 @@
+# A Simple Raptor Algorithm Implementation
+
+This package presents a straightforward implementation of the Raptor algorithm. This implementation is a copy of the
+implementation released in version 0.3.0 (commit #6ed7904) of the algorithm. Notably, the routeLatestDeparture method
+has been deliberately removed, which allowed for the elimination of all "time-type" checks within the routing algorithm.
+
+This implementation directly borrows from an earlier version of the code. Consequently, there is a significant amount of
+code duplication, when compared to the "router" package implementation. However, this is considered acceptable within
+the context of this project, as the code serves as conceptual proof rather than a foundation for future enhancements.

--- a/src/test/java/ch/naviqore/Benchmark.java
+++ b/src/test/java/ch/naviqore/Benchmark.java
@@ -54,7 +54,7 @@ final class Benchmark {
      */
     private static final int DEPARTURE_TIME_LIMIT = 8 * 60 * 60;
     private static final long RANDOM_SEED = 1234;
-    private static final int SAMPLE_SIZE = 10_000;
+    private static final int SAMPLE_SIZE = 1_000;
 
     // constants
     private static final long MONITORING_INTERVAL_MS = 30000;
@@ -73,21 +73,26 @@ final class Benchmark {
 
         RaptorRouter raptor = initializeRaptor(schedule);
 
-        // range raptor with range 1800
-        raptor.setRaptorRange(1800);
-        BenchmarkingRaptor range1800BenchmarkingRaptor = new BenchmarkingRaptor("range_1800", raptor);
-        List<RoutingResult> results = new ArrayList<>(
-                Arrays.asList(processRequests(range1800BenchmarkingRaptor, requests)));
-
         // regular raptor
         raptor.setRaptorRange(-1);
         BenchmarkingRaptor regularBenchmarkingRaptor = new BenchmarkingRaptor("regular", raptor);
-        results.addAll(Arrays.asList(processRequests(regularBenchmarkingRaptor, requests)));
+        List<RoutingResult> results = new ArrayList<>(
+                Arrays.asList(processRequests(regularBenchmarkingRaptor, requests)));
+
+        // range raptor with range 1800
+        raptor.setRaptorRange(1800);
+        BenchmarkingRaptor range1800BenchmarkingRaptor = new BenchmarkingRaptor("range_1800", raptor);
+        results.addAll(Arrays.asList(processRequests(range1800BenchmarkingRaptor, requests)));
 
         // range raptor with range 3600
         raptor.setRaptorRange(3600);
         BenchmarkingRaptor range3600BenchmarkingRaptor = new BenchmarkingRaptor("range_3600", raptor);
         results.addAll(Arrays.asList(processRequests(range3600BenchmarkingRaptor, requests)));
+
+        // range raptor with range 7200
+        raptor.setRaptorRange(7200);
+        BenchmarkingRaptor range7200BenchmarkingRaptor = new BenchmarkingRaptor("range_7200", raptor);
+        results.addAll(Arrays.asList(processRequests(range7200BenchmarkingRaptor, requests)));
 
         writeResultsToCsv(results.toArray(new RoutingResult[0]));
     }

--- a/src/test/java/ch/naviqore/Benchmark.java
+++ b/src/test/java/ch/naviqore/Benchmark.java
@@ -53,7 +53,7 @@ final class Benchmark {
      * Limit in seconds after midnight for the departure time. Only allow early departure times, otherwise many
      * connections crossing the complete schedule (region) are not feasible.
      */
-    private static final int DEPARTURE_TIME_LIMIT = 8 * 60 * 60;
+    private static final int DEPARTURE_TIME_LIMIT = 24 * 60 * 60;
     private static final long RANDOM_SEED = 1234;
     private static final int SAMPLE_SIZE = 1_000;
 

--- a/src/test/java/ch/naviqore/Benchmark.java
+++ b/src/test/java/ch/naviqore/Benchmark.java
@@ -82,23 +82,69 @@ final class Benchmark {
 
         // regular raptor
         raptor.setRaptorRange(-1);
+        raptor.setDaysToScan(1);
         BenchmarkingRaptor regularBenchmarkingRaptor = new BenchmarkingRaptor("regular", raptor);
         results.addAll(Arrays.asList(processRequests(regularBenchmarkingRaptor, requests)));
 
+        // 3-day raptor
+        raptor.setRaptorRange(-1);
+        raptor.setDaysToScan(3);
+        BenchmarkingRaptor threeDayBenchmarkingRaptor = new BenchmarkingRaptor("3_day", raptor);
+        results.addAll(Arrays.asList(processRequests(threeDayBenchmarkingRaptor, requests)));
+
+        // 5-day raptor
+        raptor.setRaptorRange(-1);
+        raptor.setDaysToScan(5);
+        BenchmarkingRaptor fiveDayBenchmarkingRaptor = new BenchmarkingRaptor("5_day", raptor);
+        results.addAll(Arrays.asList(processRequests(fiveDayBenchmarkingRaptor, requests)));
+
         // range raptor with range 1800
         raptor.setRaptorRange(1800);
+        raptor.setDaysToScan(1);
         BenchmarkingRaptor range1800BenchmarkingRaptor = new BenchmarkingRaptor("range_1800", raptor);
         results.addAll(Arrays.asList(processRequests(range1800BenchmarkingRaptor, requests)));
 
         // range raptor with range 3600
         raptor.setRaptorRange(3600);
+        raptor.setDaysToScan(1);
         BenchmarkingRaptor range3600BenchmarkingRaptor = new BenchmarkingRaptor("range_3600", raptor);
         results.addAll(Arrays.asList(processRequests(range3600BenchmarkingRaptor, requests)));
 
         // range raptor with range 7200
         raptor.setRaptorRange(7200);
+        raptor.setDaysToScan(1);
         BenchmarkingRaptor range7200BenchmarkingRaptor = new BenchmarkingRaptor("range_7200", raptor);
         results.addAll(Arrays.asList(processRequests(range7200BenchmarkingRaptor, requests)));
+
+        // range raptor with range 144400
+        raptor.setRaptorRange(14400);
+        raptor.setDaysToScan(1);
+        BenchmarkingRaptor range14400BenchmarkingRaptor = new BenchmarkingRaptor("range_14400", raptor);
+        results.addAll(Arrays.asList(processRequests(range14400BenchmarkingRaptor, requests)));
+
+        // three day range raptor with range 1800
+        raptor.setRaptorRange(1800);
+        raptor.setDaysToScan(3);
+        BenchmarkingRaptor threeDayRange1800BenchmarkingRaptor = new BenchmarkingRaptor("3_day_range_1800", raptor);
+        results.addAll(Arrays.asList(processRequests(threeDayRange1800BenchmarkingRaptor, requests)));
+
+        // three day range raptor with range 3600
+        raptor.setRaptorRange(3600);
+        raptor.setDaysToScan(3);
+        BenchmarkingRaptor threeDayRange3600BenchmarkingRaptor = new BenchmarkingRaptor("3_day_range_3600", raptor);
+        results.addAll(Arrays.asList(processRequests(threeDayRange3600BenchmarkingRaptor, requests)));
+
+        // three day range raptor with range 7200
+        raptor.setRaptorRange(7200);
+        raptor.setDaysToScan(3);
+        BenchmarkingRaptor threeDayRange7200BenchmarkingRaptor = new BenchmarkingRaptor("3_day_range_7200", raptor);
+        results.addAll(Arrays.asList(processRequests(threeDayRange7200BenchmarkingRaptor, requests)));
+
+        // three day range raptor with range 14400
+        raptor.setRaptorRange(14400);
+        raptor.setDaysToScan(3);
+        BenchmarkingRaptor threeDayRange14400BenchmarkingRaptor = new BenchmarkingRaptor("3_day_range_14400", raptor);
+        results.addAll(Arrays.asList(processRequests(threeDayRange14400BenchmarkingRaptor, requests)));
 
         writeResultsToCsv(results.toArray(new RoutingResult[0]));
     }


### PR DESCRIPTION
This pull request into "concept/benchmark" addressed 3 issues in JIRA.

- NAV-132 - "Simple" raptor implementation for future comparison with the C++ implementation (a copy of our refactored raptor algorithm from version 0.3.0) which also served as template for the C++ implementation.
- NAV-135 - Comparison between range raptor and reverse routing, which was abandoned, after seeing how little the cost for range raptor routing was.
- NAV-156 - Extension of the benchmarking script to allow comparison of multiple raptor implementations in one benchmarking run with same route requests for all raptor implementations.

@Brunner246: I think this is a good pull request for you to review, since you'll be adding your C++ implementation in a similar way.

Post-Processing of the benchmark results will be commited and sent for review in a different pull request in a python code repo.