### PR TITLE
Feature/nav 181 initialize hashset size of marked stops

### DIFF
--- a/src/main/java/ch/naviqore/raptor/router/FootpathRelaxer.java
+++ b/src/main/java/ch/naviqore/raptor/router/FootpathRelaxer.java
@@ -55,7 +55,7 @@ class FootpathRelaxer {
     void relax(int round) {
         log.debug("Relaxing footpaths for round {}", round);
         // to prevent extending transfers from stops that were only reached by footpath in the same round
-        boolean[] routeMarkedStops = queryState.getMarkedStopsMaskNextRoundClone();
+        boolean[] routeMarkedStops = queryState.cloneMarkedStopsMaskNextRound();
 
         for (int sourceStopIdx = 0; sourceStopIdx < routeMarkedStops.length; sourceStopIdx++) {
             if (!routeMarkedStops[sourceStopIdx]) {

--- a/src/main/java/ch/naviqore/raptor/router/FootpathRelaxer.java
+++ b/src/main/java/ch/naviqore/raptor/router/FootpathRelaxer.java
@@ -41,30 +41,27 @@ class FootpathRelaxer {
 
     /**
      * Relax all footpaths from all initial source stops.
-     *
-     * @param markedStopsMask the mask of the stops to be relaxed.
      */
-    void relaxInitial(boolean[] markedStopsMask) {
+    void relaxInitial() {
         log.debug("Initial relaxing of footpaths for source stops");
-        relax(0, markedStopsMask);
+        relax(0);
     }
 
     /**
      * Relax all footpaths from marked stops.
      *
-     * @param round           the current round.
-     * @param markedStopsMask the mask of the stops to be relaxed.
+     * @param round the current round.
      */
-    void relax(int round, boolean[] markedStopsMask) {
+    void relax(int round) {
         log.debug("Relaxing footpaths for round {}", round);
         // to prevent extending transfers from stops that were only reached by footpath in the same round
-        boolean[] routeMarkedStops = markedStopsMask.clone();
+        boolean[] routeMarkedStops = queryState.getMarkedStopsMaskNextRoundClone();
 
-        for (int sourceStopIdx = 0; sourceStopIdx < markedStopsMask.length; sourceStopIdx++) {
+        for (int sourceStopIdx = 0; sourceStopIdx < routeMarkedStops.length; sourceStopIdx++) {
             if (!routeMarkedStops[sourceStopIdx]) {
                 continue;
             }
-            expandFootpathsFromStop(sourceStopIdx, round, markedStopsMask);
+            expandFootpathsFromStop(sourceStopIdx, round);
         }
     }
 
@@ -73,12 +70,10 @@ class FootpathRelaxer {
      * then the target stop is marked for the next round. And the improved target time is stored in the bestTimes array
      * and the bestLabelPerRound list (including the new transfer label).
      *
-     * @param stopIdx         the index of the stop to expand transfers from.
-     * @param round           the current round to relax footpaths for.
-     * @param markedStopsMask a mask of stop indices that have been marked for scanning in the next round, which will be
-     *                        extended if new stops improve due to relaxation.
+     * @param stopIdx the index of the stop to expand transfers from.
+     * @param round   the current round to relax footpaths for.
      */
-    private void expandFootpathsFromStop(int stopIdx, int round, boolean[] markedStopsMask) {
+    private void expandFootpathsFromStop(int stopIdx, int round) {
         // if stop has no transfers, then no footpaths can be expanded
         if (stops[stopIdx].numberOfTransfers() == 0) {
             return;
@@ -123,8 +118,7 @@ class FootpathRelaxer {
             QueryState.Label label = new QueryState.Label(sourceTime, targetTime, QueryState.LabelType.TRANSFER, i,
                     NO_INDEX, transfer.targetStopIdx(), queryState.getLabel(round, stopIdx));
             queryState.setLabel(round, transfer.targetStopIdx(), label);
-            // mark stop as improved
-            markedStopsMask[transfer.targetStopIdx()] = true;
+            queryState.mark(transfer.targetStopIdx());
         }
     }
 }

--- a/src/main/java/ch/naviqore/raptor/router/Query.java
+++ b/src/main/java/ch/naviqore/raptor/router/Query.java
@@ -127,19 +127,19 @@ class Query {
         return queryState.getBestLabelsPerRound();
     }
 
-    void doRangeRaptor(boolean[] markedStops) {
+    void doRangeRaptor(boolean[] markedStopsMask) {
         // prepare range offsets
         // get initial marked stops to reset after each range offset
         List<Integer> initialMarkedStops = new ArrayList<>();
-        for (int stopIdx = 0; stopIdx < markedStops.length; stopIdx++) {
-            if (markedStops[stopIdx]) {
+        for (int stopIdx = 0; stopIdx < markedStopsMask.length; stopIdx++) {
+            if (markedStopsMask[stopIdx]) {
                 initialMarkedStops.add(stopIdx);
             }
         }
         List<Integer> rangeOffsets = getRangeOffsets(initialMarkedStops, routeScanner);
         HashMap<Integer, Integer> stopIdxSourceTimes = new HashMap<>();
-        for (int stopIdx = 0; stopIdx < markedStops.length; stopIdx++) {
-            if (!markedStops[stopIdx]) {
+        for (int stopIdx = 0; stopIdx < markedStopsMask.length; stopIdx++) {
+            if (!markedStopsMask[stopIdx]) {
                 continue;
             }
             stopIdxSourceTimes.put(stopIdx, queryState.getLabel(0, stopIdx).targetTime());
@@ -156,7 +156,7 @@ class Query {
                 int targetTime = stopIdxSourceTimes.get(stopIdx) + timeFactor * rangeOffset;
                 queryState.setLabel(0, stopIdx, copyLabelWithNewTargetTime(label, targetTime));
             }
-            doRounds(markedStops);
+            doRounds(markedStopsMask);
         }
     }
 
@@ -190,14 +190,14 @@ class Query {
             queryState.addNewRound();
 
             // scan all routs and mark stops that have improved
-            boolean[] markedStopsNext = routeScanner.scan(round, markedStopsMask);
+            boolean[] nextMarkedStopsMask = routeScanner.scan(round, markedStopsMask);
 
             // relax footpaths for all newly marked stops
-            footpathRelaxer.relax(round, markedStopsNext);
+            footpathRelaxer.relax(round, nextMarkedStopsMask);
 
             // prepare next round
-            removeSuboptimalLabelsForRound(round, markedStopsNext);
-            markedStopsMask = markedStopsNext;
+            removeSuboptimalLabelsForRound(round, nextMarkedStopsMask);
+            markedStopsMask = nextMarkedStopsMask;
             round++;
         }
     }

--- a/src/main/java/ch/naviqore/raptor/router/Query.java
+++ b/src/main/java/ch/naviqore/raptor/router/Query.java
@@ -5,7 +5,10 @@ import ch.naviqore.raptor.TimeType;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 
 import static ch.naviqore.raptor.router.QueryState.INFINITY;
 
@@ -29,6 +32,8 @@ class Query {
     private final QueryState queryState;
     private final FootpathRelaxer footpathRelaxer;
     private final RouteScanner routeScanner;
+
+    private final int numStops;
 
     private final int raptorRange;
 
@@ -65,6 +70,7 @@ class Query {
 
         targetStops = new int[targetStopIndices.length * 2];
         cutoffTime = determineCutoffTime();
+        numStops = raptorData.getStopContext().stops().length;
         queryState = new QueryState(raptorData.getStopContext().stops().length, timeType);
 
         // set up footpath relaxer and route scanner and inject stop labels and times
@@ -93,27 +99,36 @@ class Query {
     List<QueryState.Label[]> run() {
 
         // initially relax all source stops and add the newly improved stops by relaxation to the marked stops
-        Set<Integer> markedStops = initialize();
-        markedStops.addAll(footpathRelaxer.relaxInitial(sourceStopIndices));
-        markedStops = removeSuboptimalLabelsForRound(0, markedStops);
+        boolean[] markedStopsMask = initialize();
+        footpathRelaxer.relaxInitial(markedStopsMask);
+        removeSuboptimalLabelsForRound(0, markedStopsMask);
 
         // if range is 0 or smaller there is no range, and we don't need to rerun rounds with different start offsets
         if (raptorRange <= 0) {
-            doRounds(markedStops);
+            doRounds(markedStopsMask);
         } else {
-            doRangeRaptor(markedStops);
+            doRangeRaptor(markedStopsMask);
         }
         return queryState.getBestLabelsPerRound();
     }
 
-    void doRangeRaptor(Set<Integer> markedStops) {
+    void doRangeRaptor(boolean[] markedStops) {
         // prepare range offsets
-        List<Integer> rangeOffsets = getRangeOffsets(markedStops, routeScanner);
+        // get initial marked stops to reset after each range offset
+        List<Integer> initialMarkedStops = new ArrayList<>();
+        for (int stopIdx = 0; stopIdx < markedStops.length; stopIdx++) {
+            if (markedStops[stopIdx]) {
+                initialMarkedStops.add(stopIdx);
+            }
+        }
+        List<Integer> rangeOffsets = getRangeOffsets(initialMarkedStops, routeScanner);
         HashMap<Integer, Integer> stopIdxSourceTimes = new HashMap<>();
-        for (int stopIdx : markedStops) {
+        for (int stopIdx = 0; stopIdx < markedStops.length; stopIdx++) {
+            if (!markedStops[stopIdx]) {
+                continue;
+            }
             stopIdxSourceTimes.put(stopIdx, queryState.getLabel(0, stopIdx).targetTime());
         }
-
         // scan all range offsets in reverse order (earliest arrival / latest departure first)
         for (int offsetIdx = rangeOffsets.size() - 1; offsetIdx >= 0; offsetIdx--) {
             int rangeOffset = rangeOffsets.get(offsetIdx);
@@ -121,7 +136,7 @@ class Query {
             log.debug("Running rounds with range offset {}", rangeOffset);
 
             // set source times to the source times of the previous round
-            for (int stopIdx : markedStops) {
+            for (int stopIdx : initialMarkedStops) {
                 QueryState.Label label = queryState.getLabel(0, stopIdx);
                 int targetTime = stopIdxSourceTimes.get(stopIdx) + timeFactor * rangeOffset;
                 queryState.setLabel(0, stopIdx, copyLabelWithNewTargetTime(label, targetTime));
@@ -147,26 +162,44 @@ class Query {
     /**
      * Method to perform the rounds of the routing algorithm (see {@link #run()}).
      *
-     * @param markedStops the initially marked stops.
+     * @param markedStopsMask the initially marked stops mask.
      */
-    private void doRounds(Set<Integer> markedStops) {
+    private void doRounds(boolean[] markedStopsMask) {
 
         // continue with further rounds as long as there are new marked stops
         int round = 1;
-        while (!markedStops.isEmpty() && (round - 1) <= config.getMaximumTransferNumber()) {
+
+        // check if marked stops has any true values
+        while (hasMarkedStops(markedStopsMask) && (round - 1) <= config.getMaximumTransferNumber()) {
             // add label layer for new round
             queryState.addNewRound();
 
             // scan all routs and mark stops that have improved
-            Set<Integer> markedStopsNext = routeScanner.scan(round, markedStops);
+            boolean[] markedStopsNext = routeScanner.scan(round, markedStopsMask);
 
             // relax footpaths for all newly marked stops
-            markedStopsNext.addAll(footpathRelaxer.relax(round, markedStopsNext));
+            footpathRelaxer.relax(round, markedStopsNext);
 
             // prepare next round
-            markedStops = removeSuboptimalLabelsForRound(round, markedStopsNext);
+            removeSuboptimalLabelsForRound(round, markedStopsNext);
+            markedStopsMask = markedStopsNext;
             round++;
         }
+    }
+
+    /**
+     * Check if there are any marked stops in the marked stops mask.
+     *
+     * @param markedStopsMask the marked stops mask to check.
+     * @return true if there are any marked stops, false otherwise.
+     */
+    private static boolean hasMarkedStops(boolean[] markedStopsMask) {
+        for (boolean b : markedStopsMask) {
+            if (b) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -180,13 +213,13 @@ class Query {
      * 10:10, 10:20, and Route B has departures at 10:05, 10:15, 10:25, the range offsets are be 0, 10, 20 and not 0, 5,
      * 10, 15, 20, 25 (note real values are in seconds and not minutes --> *60).
      *
-     * @param markedStops  the marked stops to get the range offsets for.
-     * @param routeScanner the route scanner to get the trip offsets for the stops.
+     * @param initialMarkedStops the initial marked stops to get the range offsets for.
+     * @param routeScanner       the route scanner to get the trip offsets for the stops.
      * @return the range offsets (in seconds) applicable for all marked stops.
      */
-    private List<Integer> getRangeOffsets(Set<Integer> markedStops, RouteScanner routeScanner) {
+    private List<Integer> getRangeOffsets(List<Integer> initialMarkedStops, RouteScanner routeScanner) {
         ArrayList<Integer> rangeOffsets = new ArrayList<>();
-        for (int stopIdx : markedStops) {
+        for (int stopIdx : initialMarkedStops) {
             List<Integer> stopRangeOffsets = routeScanner.getTripOffsetsForStop(stopIdx, raptorRange);
             for (int i = 0; i < stopRangeOffsets.size(); i++) {
                 // if the rangeOffsets list is not long enough, add the offset
@@ -213,7 +246,8 @@ class Query {
      *
      * @return the initially marked stops.
      */
-    Set<Integer> initialize() {
+    boolean[] initialize() {
+        boolean[] markedStopsMask = new boolean[numStops];
         log.debug("Initializing global best times per stop and best labels per round");
 
         // fill target stops
@@ -224,7 +258,6 @@ class Query {
         }
 
         // set initial labels, best time and mark source stops
-        Set<Integer> markedStops = new HashSet<>();
         for (int i = 0; i < sourceStopIndices.length; i++) {
             int currentStopIdx = sourceStopIndices[i];
             int targetTime = sourceTimes[i];
@@ -233,42 +266,41 @@ class Query {
                     QueryState.NO_INDEX, QueryState.NO_INDEX, currentStopIdx, null);
             queryState.setLabel(0, currentStopIdx, label);
             queryState.setBestTime(currentStopIdx, targetTime);
-
-            markedStops.add(currentStopIdx);
+            markedStopsMask[currentStopIdx] = true;
         }
 
-        return markedStops;
+        return markedStopsMask;
     }
 
     /**
      * Nullify labels that are suboptimal for the current round. This method checks if the label time is worse than the
      * optimal time mark and removes the mark for the next round and nullifies the label in this case.
      *
-     * @param round       the round to remove suboptimal labels for.
-     * @param markedStops the marked stops to check for suboptimal labels.
+     * @param round           the round to remove suboptimal labels for.
+     * @param markedStopsMask the marked stops mask to check for suboptimal labels.
      */
-    Set<Integer> removeSuboptimalLabelsForRound(int round, Set<Integer> markedStops) {
+    void removeSuboptimalLabelsForRound(int round, boolean[] markedStopsMask) {
         int bestTime = getBestTimeForAllTargetStops();
 
         if (bestTime == INFINITY || bestTime == -INFINITY) {
-            return markedStops;
+            return;
         }
 
-        Set<Integer> markedStopsClean = new HashSet<>();
-        for (int stopIdx : markedStops) {
+        for (int stopIdx = 0; stopIdx < markedStopsMask.length; stopIdx++) {
+            if (!markedStopsMask[stopIdx]) {
+                continue;
+            }
             QueryState.Label label = queryState.getLabel(round, stopIdx);
             if (label != null) {
                 if (timeType == TimeType.DEPARTURE && label.targetTime() > bestTime) {
                     queryState.setLabel(round, stopIdx, null);
+                    markedStopsMask[stopIdx] = false;
                 } else if (timeType == TimeType.ARRIVAL && label.targetTime() < bestTime) {
                     queryState.setLabel(round, stopIdx, null);
-                } else {
-                    markedStopsClean.add(stopIdx);
+                    markedStopsMask[stopIdx] = false;
                 }
             }
         }
-
-        return markedStopsClean;
     }
 
     /**

--- a/src/main/java/ch/naviqore/raptor/router/Query.java
+++ b/src/main/java/ch/naviqore/raptor/router/Query.java
@@ -81,6 +81,21 @@ class Query {
     }
 
     /**
+     * Check if there are any marked stops in the marked stops mask.
+     *
+     * @param markedStopsMask the marked stops mask to check.
+     * @return true if there are any marked stops, false otherwise.
+     */
+    private static boolean hasMarkedStops(boolean[] markedStopsMask) {
+        for (boolean b : markedStopsMask) {
+            if (b) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Main control flow of the routing algorithm. Spawns from source stops, coordinates route scanning, footpath
      * relaxation, and time/label updates in the correct order.
      * <p>
@@ -185,21 +200,6 @@ class Query {
             markedStopsMask = markedStopsNext;
             round++;
         }
-    }
-
-    /**
-     * Check if there are any marked stops in the marked stops mask.
-     *
-     * @param markedStopsMask the marked stops mask to check.
-     * @return true if there are any marked stops, false otherwise.
-     */
-    private static boolean hasMarkedStops(boolean[] markedStopsMask) {
-        for (boolean b : markedStopsMask) {
-            if (b) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/src/main/java/ch/naviqore/raptor/router/RouteScanner.java
+++ b/src/main/java/ch/naviqore/raptor/router/RouteScanner.java
@@ -114,6 +114,9 @@ class RouteScanner {
         // scan selected routes and mark stops with improved times
         boolean[] markedStopsMaskNext = new boolean[stops.length];
         for (int currentRouteIdx = 0; currentRouteIdx < routesToScan.length; currentRouteIdx++) {
+            if (!routesToScan[currentRouteIdx]) {
+                continue;
+            }
             scanRoute(currentRouteIdx, round, markedStopsMask, markedStopsMaskNext);
         }
 

--- a/src/main/java/ch/naviqore/raptor/router/RouteScanner.java
+++ b/src/main/java/ch/naviqore/raptor/router/RouteScanner.java
@@ -114,7 +114,7 @@ class RouteScanner {
         log.debug("Scanning routes for round {} ({})", round, routesToScan);
 
         // scan selected routes and mark stops with improved times
-        Set<Integer> markedStopsNext = new HashSet<>();
+        Set<Integer> markedStopsNext = new HashSet<>(stops.length);
         for (int currentRouteIdx : routesToScan) {
             scanRoute(currentRouteIdx, round, markedStops, markedStopsNext);
         }
@@ -128,7 +128,7 @@ class RouteScanner {
      * @param markedStops the set of marked stops from the previous round.
      */
     private Set<Integer> getRoutesToScan(Set<Integer> markedStops) {
-        Set<Integer> routesToScan = new HashSet<>();
+        Set<Integer> routesToScan = new HashSet<>(stops.length);
         for (int stopIdx : markedStops) {
             Stop currentStop = stops[stopIdx];
             int stopRouteIdx = currentStop.stopRouteIdx();

--- a/src/test/java/ch/naviqore/Benchmark.java
+++ b/src/test/java/ch/naviqore/Benchmark.java
@@ -35,7 +35,7 @@ import java.util.*;
  * Measures the time it takes to route a number of requests using Raptor algorithm on large GTFS datasets.
  * <p>
  * Note: To run this benchmark, ensure that the log level is set to INFO in the
- * {@code src/test/resources/log4j2-test.properties} file.
+ * {@code src/test/resources/logback-test.xml} file.
  *
  * @author munterfi
  */

--- a/src/test/java/ch/naviqore/Benchmark.java
+++ b/src/test/java/ch/naviqore/Benchmark.java
@@ -52,7 +52,7 @@ final class Benchmark {
      * Limit in seconds after midnight for the departure time. Only allow early departure times, otherwise many
      * connections crossing the complete schedule (region) are not feasible.
      */
-    private static final int DEPARTURE_TIME_LIMIT = 8 * 60 * 60;
+    private static final int DEPARTURE_TIME_LIMIT = 24 * 60 * 60;
     private static final long RANDOM_SEED = 1234;
     private static final int SAMPLE_SIZE = 10_000;
 


### PR DESCRIPTION
Created new pull request, to allow you to review the request.

Change is that boolean[] arrays are used to mask routesToScan and markedStops instead of HashSets. Performance has been improved significantly.

# Original:
![image](https://github.com/user-attachments/assets/c26a21d0-5348-4623-9bb9-2ef56c5be3d1)

# With Hashset set to size of Stops/Routes
![image](https://github.com/user-attachments/assets/d50c85be-c4ec-4c99-9fb9-0c049039e0b5)

# With Boolean Arrays
![image](https://github.com/user-attachments/assets/c924ef40-5595-494b-b72a-8d67433e32a6)
