### PR TITLE
ORG: v0.5.1 - Bump patch version to 0.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ch.naviqore</groupId>
     <artifactId>public-transit-service</artifactId>
-    <version>0.5.0</version>
+    <version>0.5.1</version>
 
     <name>Public Transit Service</name>
     <description>

--- a/src/main/java/ch/naviqore/raptor/router/Query.java
+++ b/src/main/java/ch/naviqore/raptor/router/Query.java
@@ -81,21 +81,6 @@ class Query {
     }
 
     /**
-     * Check if there are any marked stops in the marked stops mask.
-     *
-     * @param markedStopsMask the marked stops mask to check.
-     * @return true if there are any marked stops, false otherwise.
-     */
-    private static boolean hasMarkedStops(boolean[] markedStopsMask) {
-        for (boolean b : markedStopsMask) {
-            if (b) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
      * Main control flow of the routing algorithm. Spawns from source stops, coordinates route scanning, footpath
      * relaxation, and time/label updates in the correct order.
      * <p>


### PR DESCRIPTION
Draft new release `v0.5.1` to conclude the current sprint.

Release notes:

```
## public-transit-service 0.5.1

This release introduces performance enhancements of the raptor router and a transition to the MIT license.

### New Features
- **Performance Optimization in Raptor Rounds**: Improved performance by replacing the HashSet for marked stops with boolean stop mask arrays.
- **Sorted Stop Results**: Stops are now sorted by name in the `getStops(String like)` API to enhance the user experience.
- **MIT License**: Changed project licensing from GPLv3 to MIT for better alignment with open-source best practices.

### Bug Fixes
- **Range Raptor Fix**: Resolved an issue where Range RAPTOR failed to return routes when no departure was found, ensuring reliable route results.

--> PLACE AUTOMATICALLY GENERATED CHANGELOG HERE
```