### PR TITLE
release/v1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ch.naviqore</groupId>
     <artifactId>public-transit-service</artifactId>
-    <version>0.5.1</version>
+    <version>1.0.0</version>
 
     <name>Public Transit Service</name>
     <description>


### PR DESCRIPTION
Draft new release v1.0.0 to conclude the current sprint and the Master's thesis.

Release notes:

```
## public-transit-service 1.0.0

We are excited to announce the official release of **v1.0.0** of the public transit service and conclude our Master's thesis!

### Bug Fixes
- **Headsign Field in Trips**: The headsign field in the `trips.txt` is not a mandatory field.

--> PLACE AUTOMATICALLY GENERATED CHANGELOG HERE
```