### PR TITLE
145 bug non pareto optimal solution

### DIFF
--- a/src/main/java/ch/naviqore/raptor/router/LabelPostprocessor.java
+++ b/src/main/java/ch/naviqore/raptor/router/LabelPostprocessor.java
@@ -70,16 +70,12 @@ class LabelPostprocessor {
                                                        Map<Integer, Integer> targetStops, LocalDate referenceDate) {
         final List<Connection> connections = new ArrayList<>();
 
-        // this additional tracking variable is needed to filter out non pareto optimal connections from range raptor,
-        // as the pareto optimal solution for a later departure might have actually been fastest with more rounds where
-        // the final best solution has fewer rounds and is faster
-        int overallBestTime = timeType == TimeType.DEPARTURE ? INFINITY : -INFINITY;
+        int bestTime = timeType == TimeType.DEPARTURE ? INFINITY : -INFINITY;
 
         // iterate over all rounds
         for (QueryState.Label[] labels : bestLabelsPerRound) {
 
             QueryState.Label label = null;
-            int bestTime = timeType == TimeType.DEPARTURE ? INFINITY : -INFINITY;
 
             for (Map.Entry<Integer, Integer> entry : targetStops.entrySet()) {
                 int targetStopIdx = entry.getKey();
@@ -91,17 +87,15 @@ class LabelPostprocessor {
 
                 if (timeType == TimeType.DEPARTURE) {
                     int actualArrivalTime = currentLabel.targetTime() + targetStopWalkingTime;
-                    if (actualArrivalTime < bestTime && actualArrivalTime < overallBestTime) {
+                    if (actualArrivalTime < bestTime) {
                         label = currentLabel;
                         bestTime = actualArrivalTime;
-                        overallBestTime = actualArrivalTime;
                     }
                 } else {
                     int actualDepartureTime = currentLabel.targetTime() - targetStopWalkingTime;
-                    if (actualDepartureTime > bestTime && actualDepartureTime > overallBestTime) {
+                    if (actualDepartureTime > bestTime) {
                         label = currentLabel;
                         bestTime = actualDepartureTime;
-                        overallBestTime = actualDepartureTime;
                     }
                 }
             }

--- a/src/main/java/ch/naviqore/raptor/router/LabelPostprocessor.java
+++ b/src/main/java/ch/naviqore/raptor/router/LabelPostprocessor.java
@@ -70,6 +70,11 @@ class LabelPostprocessor {
                                                        Map<Integer, Integer> targetStops, LocalDate referenceDate) {
         final List<Connection> connections = new ArrayList<>();
 
+        // this additional tracking variable is needed to filter out non pareto optimal connections from range raptor,
+        // as the pareto optimal solution for a later departure might have actually been fastest with more rounds where
+        // the final best solution has fewer rounds and is faster
+        int overallBestTime = timeType == TimeType.DEPARTURE ? INFINITY : -INFINITY;
+
         // iterate over all rounds
         for (QueryState.Label[] labels : bestLabelsPerRound) {
 
@@ -86,15 +91,17 @@ class LabelPostprocessor {
 
                 if (timeType == TimeType.DEPARTURE) {
                     int actualArrivalTime = currentLabel.targetTime() + targetStopWalkingTime;
-                    if (actualArrivalTime < bestTime) {
+                    if (actualArrivalTime < bestTime && actualArrivalTime < overallBestTime) {
                         label = currentLabel;
                         bestTime = actualArrivalTime;
+                        overallBestTime = actualArrivalTime;
                     }
                 } else {
                     int actualDepartureTime = currentLabel.targetTime() - targetStopWalkingTime;
-                    if (actualDepartureTime > bestTime) {
+                    if (actualDepartureTime > bestTime && actualDepartureTime > overallBestTime) {
                         label = currentLabel;
                         bestTime = actualDepartureTime;
+                        overallBestTime = actualDepartureTime;
                     }
                 }
             }

--- a/src/main/java/ch/naviqore/raptor/router/QueryState.java
+++ b/src/main/java/ch/naviqore/raptor/router/QueryState.java
@@ -111,14 +111,22 @@ final class QueryState {
      * different label types (transfer vs. route), as the same stop transfer time is not considered.
      */
     int getActualBestTime(int stopIdx) {
-        for (int i = bestLabelsPerRound.size() - 1; i >= 0; i--) {
-            Label label = bestLabelsPerRound.get(i)[stopIdx];
+        int best_time = (timeType == TimeType.DEPARTURE) ? INFINITY : -INFINITY;
+
+        // because range raptor potentially fills target times in higher rounds which are not the best solutions, every
+        // round has to be looked at.
+        for (Label[] labels : bestLabelsPerRound) {
+            Label label = labels[stopIdx];
             if (label != null) {
-                return label.targetTime;
+                if (timeType == TimeType.DEPARTURE) {
+                    best_time = Math.min(best_time, label.targetTime);
+                } else {
+                    best_time = Math.max(best_time, label.targetTime);
+                }
             }
         }
 
-        return (timeType == TimeType.DEPARTURE) ? INFINITY : -INFINITY;
+        return best_time;
     }
 
     /**

--- a/src/test/java/ch/naviqore/raptor/router/RaptorRouterTestBuilder.java
+++ b/src/test/java/ch/naviqore/raptor/router/RaptorRouterTestBuilder.java
@@ -160,6 +160,11 @@ public class RaptorRouterTestBuilder {
         return this;
     }
 
+    public RaptorRouterTestBuilder withAddRoute4_RS(int offset, int headway, int travelTime, int dwellTime) {
+        routes.add(new Route("R4", List.of("R", "P", "F", "S"), offset, headway, travelTime, dwellTime));
+        return this;
+    }
+
     public RaptorRouterTestBuilder withAddRoute5_AH_selfIntersecting() {
         routes.add(new Route("R5", List.of("A", "B", "C", "D", "E", "F", "P", "O", "N", "K", "J", "I", "B", "H")));
         return this;


### PR DESCRIPTION
Found the issue, the problem was only present in range raptor configurations and can be considered somewhat edge case.

In this exact case the problem was that there are many departures from Wankdorf and therefore a raptor routing request was made in 6 minute increments starting from the latest time (in my case range 1800s) --> 12:15 (when query time was set at 11:45). At 12:15 (or 12:09, 12:03, 11:57) the optimal earliest arrival time was found with 3 rounds and since the same bestLabelsPerRound data structure is used for all, there was a label set in round 3. And then even if the earliest arrival time is then later found with a 2 round connection, this label will never be removed, thus will be returned without post processing. This post processing / filtering is now done in ch.naviqore.raptor.router.LabelPostprocessor.reconstructParetoOptimalSolutions (commit: 48fb7c3).

A further minor bug (with no big effect) was also found in the process, the method ch.naviqore.raptor.router.QueryState.getActualBestTime did actually not return the actual best time, as it was looking for the highest round label which was not null for a given stop. Again for range raptor the highest round might not always be the actual best time and thus it's better to check all possible times to determine the best. Fix implemented in (d3895b1).

I haven't implemented any tests, as coming up with a dummy schedule to cover this in the raptor tests is currently beyond my mental capacity. And this seems to niche to justify using reflections to do real unit tests on underlying methods.

PS: @munterfi If you feel like implementing a dummy schedule feel free. I'll pay you a beer, else I might do this tomorrow as a small challenge.