### PR TITLE
180 bug non deterministic solution order in raptorrouter when two solutions have the same arrival time

### DIFF
--- a/src/main/java/ch/naviqore/raptor/router/RaptorRouter.java
+++ b/src/main/java/ch/naviqore/raptor/router/RaptorRouter.java
@@ -209,7 +209,7 @@ public class RaptorRouter implements RaptorAlgorithm, RaptorData {
             }
 
             // loop over all stop pairs and check if stop exists in raptor, then validate departure time
-            Map<Integer, Integer> validStopIds = new HashMap<>();
+            Map<Integer, Integer> validStopIds = new LinkedHashMap<>();
             for (Map.Entry<String, Integer> entry : stops.entrySet()) {
                 String stopId = entry.getKey();
                 int time = entry.getValue();

--- a/src/test/java/ch/naviqore/service/gtfs/raptor/GtfsRaptorTestSchedule.java
+++ b/src/test/java/ch/naviqore/service/gtfs/raptor/GtfsRaptorTestSchedule.java
@@ -53,7 +53,7 @@ public class GtfsRaptorTestSchedule {
         builder.addTrip("T1", "R1", "always", "C1");
         builder.addStopTime("T1", "A", new ServiceDayTime(60), new ServiceDayTime(120));
         builder.addStopTime("T1", "B1", new ServiceDayTime(180), new ServiceDayTime(240));
-        builder.addStopTime("T1", "C1", new ServiceDayTime(301), new ServiceDayTime(360));
+        builder.addStopTime("T1", "C1", new ServiceDayTime(300), new ServiceDayTime(360));
 
         // Route 2 goes from A, B2, C
         builder.addRoute("R2", "agency", "R2", "R2", RouteType.parse(1));


### PR DESCRIPTION
Found the issue for the non-deterministic behavior. The problem was (or is) that the GTFS schedule is built from hashmaps (unsorted) and therefore the conversion to RAPTOR arrays results in potentially different solutions. In the case of the test that raised the issue C1 and C were either stop idx 2,4 or 4,2 (based on which route was built first in the raptor conversion). Theoretically one could ensure that the raptor conversion always builds in consistent manner using various sorting etc. However, I've opted for the simpler approach of ensuring that the target and source stop ids are always in the same order as requested, i.e. if [C, C1] is requested, C will always be checked before C1 when looking for optimal solutions after each round.

Regarding testing, I've played around with @RepeatedTest, but it seems that even if I run the test 100 times, they either pass 100 times or fail 100 times. So the root cause for the different raptor conversions must lie in compilation (defining hash functions at random?)