### PR TITLE
181 feature merge consecutive walks at connection start or end at the service level

### DIFF
--- a/src/main/java/ch/naviqore/raptor/QueryConfig.java
+++ b/src/main/java/ch/naviqore/raptor/QueryConfig.java
@@ -29,8 +29,6 @@ public class QueryConfig {
     private EnumSet<TravelMode> allowedTravelModes = EnumSet.allOf(TravelMode.class);
 
     @Setter
-    private boolean doInitialTransferRelaxation = true;
-    @Setter
     private boolean allowSourceTransfer = true;
     @Setter
     private boolean allowTargetTransfer = true;

--- a/src/main/java/ch/naviqore/raptor/QueryConfig.java
+++ b/src/main/java/ch/naviqore/raptor/QueryConfig.java
@@ -31,8 +31,6 @@ public class QueryConfig {
     @Setter
     private boolean doInitialTransferRelaxation = true;
     @Setter
-    private boolean allowConsecutiveTransfers = false;
-    @Setter
     private boolean allowSourceTransfer = true;
     @Setter
     private boolean allowTargetTransfer = true;

--- a/src/main/java/ch/naviqore/raptor/QueryConfig.java
+++ b/src/main/java/ch/naviqore/raptor/QueryConfig.java
@@ -28,6 +28,16 @@ public class QueryConfig {
     @Setter
     private EnumSet<TravelMode> allowedTravelModes = EnumSet.allOf(TravelMode.class);
 
+    @Setter
+    private boolean doInitialTransferRelaxation = true;
+    @Setter
+    private boolean allowConsecutiveTransfers = false;
+    @Setter
+    private boolean allowSourceTransfer = true;
+    @Setter
+    private boolean allowTargetTransfer = true;
+
+
     public QueryConfig(int maximumWalkingDuration, int minimumTransferDuration, int maximumTransferNumber,
                        int maximumTravelTime, boolean wheelchairAccessible, boolean bikeAccessible,
                        EnumSet<TravelMode> allowedTravelModes) {

--- a/src/main/java/ch/naviqore/raptor/QueryConfig.java
+++ b/src/main/java/ch/naviqore/raptor/QueryConfig.java
@@ -33,7 +33,6 @@ public class QueryConfig {
     @Setter
     private boolean allowTargetTransfer = true;
 
-
     public QueryConfig(int maximumWalkingDuration, int minimumTransferDuration, int maximumTransferNumber,
                        int maximumTravelTime, boolean wheelchairAccessible, boolean bikeAccessible,
                        EnumSet<TravelMode> allowedTravelModes) {

--- a/src/main/java/ch/naviqore/raptor/router/FootpathRelaxer.java
+++ b/src/main/java/ch/naviqore/raptor/router/FootpathRelaxer.java
@@ -3,7 +3,6 @@ package ch.naviqore.raptor.router;
 import ch.naviqore.raptor.TimeType;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -26,17 +25,17 @@ class FootpathRelaxer {
     private final QueryState queryState;
 
     /**
-     * @param queryState                the query state with the best time per stop and label per stop and round.
-     * @param raptorData                the current raptor data structures.
-     * @param minimumTransferDuration   The minimum transfer duration time, since this is intended as rest period (e.g.
-     *                                  coffee break) it is added to the walk time.
-     * @param maximumWalkingDuration    The maximum walking duration to reach the target stop. If the walking duration
-     *                                  exceeds this value, the target stop is not reached.
-     * @param timeType                  the time type (arrival or departure).
-     * @param allowSourceTransfers      defines if transfers from source stops are possible
-     * @param allowTargetTransfers      defines if transfers to target stops are possible
-     * @param targetStopIndices         array holding all indices of target stops, used to check if transfer target is
-     *                                  target stop in case allowTargetTransfers is false
+     * @param queryState              the query state with the best time per stop and label per stop and round.
+     * @param raptorData              the current raptor data structures.
+     * @param minimumTransferDuration The minimum transfer duration time, since this is intended as rest period (e.g.
+     *                                coffee break) it is added to the walk time.
+     * @param maximumWalkingDuration  The maximum walking duration to reach the target stop. If the walking duration
+     *                                exceeds this value, the target stop is not reached.
+     * @param timeType                the time type (arrival or departure).
+     * @param allowSourceTransfers    defines if transfers from source stops are possible
+     * @param allowTargetTransfers    defines if transfers to target stops are possible
+     * @param targetStopIndices       array holding all indices of target stops, used to check if transfer target is
+     *                                target stop in case allowTargetTransfers is false
      */
     FootpathRelaxer(QueryState queryState, RaptorData raptorData, int minimumTransferDuration,
                     int maximumWalkingDuration, TimeType timeType, boolean allowSourceTransfers,
@@ -112,7 +111,7 @@ class FootpathRelaxer {
         QueryState.Label previousLabel = queryState.getLabel(round, stopIdx);
 
         // handle case where initial transfer relaxation was not performed
-        if( round == 1 && previousLabel == null ){
+        if (round == 1 && previousLabel == null) {
             previousLabel = queryState.getLabel(0, stopIdx);
         }
 

--- a/src/main/java/ch/naviqore/raptor/router/FootpathRelaxer.java
+++ b/src/main/java/ch/naviqore/raptor/router/FootpathRelaxer.java
@@ -81,6 +81,11 @@ class FootpathRelaxer {
         Stop sourceStop = stops[stopIdx];
         QueryState.Label previousLabel = queryState.getLabel(round, stopIdx);
 
+        // handle case where initial transfer relaxation was not performed
+        if( round == 1 && previousLabel == null ){
+            previousLabel = queryState.getLabel(0, stopIdx);
+        }
+
         // do not relax footpath from stop that was only reached by footpath in the same round
         if (previousLabel == null || previousLabel.type() == QueryState.LabelType.TRANSFER) {
             return;
@@ -116,7 +121,7 @@ class FootpathRelaxer {
             queryState.setBestTime(transfer.targetStopIdx(), comparableTargetTime);
             // add real target time to label
             QueryState.Label label = new QueryState.Label(sourceTime, targetTime, QueryState.LabelType.TRANSFER, i,
-                    NO_INDEX, transfer.targetStopIdx(), queryState.getLabel(round, stopIdx));
+                    NO_INDEX, transfer.targetStopIdx(), previousLabel);
             queryState.setLabel(round, transfer.targetStopIdx(), label);
             queryState.mark(transfer.targetStopIdx());
         }

--- a/src/main/java/ch/naviqore/raptor/router/LabelPostprocessor.java
+++ b/src/main/java/ch/naviqore/raptor/router/LabelPostprocessor.java
@@ -340,7 +340,9 @@ class LabelPostprocessor {
                                         TimeType timeType) {
         if (timeType == TimeType.DEPARTURE && stopTime.departure() <= routeLabel.targetTime() && stopTime.departure() >= transferLabel.sourceTime()) {
             return true;
-        } else return timeType == TimeType.ARRIVAL && stopTime.arrival() >= routeLabel.targetTime() && stopTime.arrival() <= transferLabel.sourceTime();
+        } else {
+            return timeType == TimeType.ARRIVAL && stopTime.arrival() >= routeLabel.targetTime() && stopTime.arrival() <= transferLabel.sourceTime();
+        }
     }
 
     /**

--- a/src/main/java/ch/naviqore/raptor/router/LabelPostprocessor.java
+++ b/src/main/java/ch/naviqore/raptor/router/LabelPostprocessor.java
@@ -261,8 +261,8 @@ class LabelPostprocessor {
         // if stopTime is null, then the stop is not part of the trip of the route label, if stop time is not null, then
         // check if the temporal order of the stop time and the route label is correct (e.g. for time type departure the
         // stop time departure must be before the route label target time)
-        if (stopTime == null || (fromTarget ? !canStopTimeBeTarget(stopTime, routeLabel.targetTime(),
-                timeType) : !canStopTimeBeSource(stopTime, routeLabel.sourceTime(), timeType))) {
+        if (stopTime == null || (fromTarget ? !canStopTimeBeTarget(stopTime, routeLabel, transferLabel,
+                timeType) : !canStopTimeBeSource(stopTime, routeLabel, transferLabel, timeType))) {
             if (!fromTarget) {
                 maybeShiftSourceTransferCloserToFirstRoute(labels, transferLabel, routeLabel, transferLabelIndex);
             }
@@ -330,15 +330,17 @@ class LabelPostprocessor {
      * before the route target time for departure time type and the stop time arrival is after the route target time for
      * arrival time type.
      *
-     * @param stopTime        the stop time to check.
-     * @param routeTargetTime the target time of the route, of the potential source stop time.
-     * @param timeType        the time type (arrival or departure).
+     * @param stopTime      the stop time to check.
+     * @param routeLabel    the second label of the connection (a route leg)
+     * @param transferLabel the first label of the connection which may be replaced by the route (a transfer leg)
+     * @param timeType      the time type (arrival or departure).
      * @return true if the stop time can be the source of the route target time, false otherwise.
      */
-    private boolean canStopTimeBeSource(StopTime stopTime, int routeTargetTime, TimeType timeType) {
-        if (timeType == TimeType.DEPARTURE && stopTime.departure() <= routeTargetTime) {
+    private boolean canStopTimeBeSource(StopTime stopTime, QueryState.Label routeLabel, QueryState.Label transferLabel,
+                                        TimeType timeType) {
+        if (timeType == TimeType.DEPARTURE && stopTime.departure() <= routeLabel.targetTime() && stopTime.departure() >= transferLabel.sourceTime()) {
             return true;
-        } else return timeType == TimeType.ARRIVAL && stopTime.arrival() >= routeTargetTime;
+        } else return timeType == TimeType.ARRIVAL && stopTime.arrival() >= routeLabel.targetTime() && stopTime.arrival() <= transferLabel.sourceTime();
     }
 
     /**
@@ -346,15 +348,19 @@ class LabelPostprocessor {
      * after the route source time for departure time type and the stop time departure is before the route source time
      * for arrival time type.
      *
-     * @param stopTime        the stop time to check.
-     * @param routeSourceTime the source time of the route, of the potential target stop time.
-     * @param timeType        the time type (arrival or departure).
+     * @param stopTime      the stop time to check.
+     * @param routeLabel    second last label of the connection done by route
+     * @param transferLabel last label of the connection which is a transfer
+     * @param timeType      the time type (arrival or departure).
      * @return true if the stop time can be the target of the route source time, false otherwise.
      */
-    private boolean canStopTimeBeTarget(StopTime stopTime, int routeSourceTime, TimeType timeType) {
-        if (timeType == TimeType.DEPARTURE && stopTime.arrival() >= routeSourceTime) {
+    private boolean canStopTimeBeTarget(StopTime stopTime, QueryState.Label routeLabel, QueryState.Label transferLabel,
+                                        TimeType timeType) {
+        if (timeType == TimeType.DEPARTURE && stopTime.arrival() >= routeLabel.sourceTime() && stopTime.arrival() <= transferLabel.targetTime()) {
             return true;
-        } else return timeType == TimeType.ARRIVAL && stopTime.departure() <= routeSourceTime;
+        } else {
+            return timeType == TimeType.ARRIVAL && stopTime.departure() <= routeLabel.sourceTime() && stopTime.departure() >= transferLabel.targetTime();
+        }
     }
 
     private @Nullable StopTime getTripStopTimeForStopInTrip(int stopIdx, int routeIdx, int tripOffset) {

--- a/src/main/java/ch/naviqore/raptor/router/Query.java
+++ b/src/main/java/ch/naviqore/raptor/router/Query.java
@@ -76,7 +76,7 @@ class Query {
         // set up footpath relaxer and route scanner and inject stop labels and times
         footpathRelaxer = new FootpathRelaxer(queryState, raptorData, config.getMinimumTransferDuration(),
                 config.getMaximumWalkingDuration(), timeType, config.isAllowSourceTransfer(),
-                config.isAllowTargetTransfer(), config.isAllowConsecutiveTransfers(), targetStopIndices);
+                config.isAllowTargetTransfer(), targetStopIndices);
         routeScanner = new RouteScanner(queryState, raptorData, config, timeType, referenceDate,
                 raptorConfig.getDaysToScan());
     }

--- a/src/main/java/ch/naviqore/raptor/router/Query.java
+++ b/src/main/java/ch/naviqore/raptor/router/Query.java
@@ -100,8 +100,11 @@ class Query {
 
         // initially relax all source stops and add the newly improved stops by relaxation to the marked stops
         initialize();
-        footpathRelaxer.relaxInitial();
-        removeSuboptimalLabelsForRound(0);
+
+        if (config.isDoInitialTransferRelaxation()) {
+            footpathRelaxer.relaxInitial();
+            removeSuboptimalLabelsForRound(0);
+        }
 
         // if range is 0 or smaller there is no range, and we don't need to rerun rounds with different start offsets
         if (raptorRange <= 0) {

--- a/src/main/java/ch/naviqore/raptor/router/Query.java
+++ b/src/main/java/ch/naviqore/raptor/router/Query.java
@@ -102,10 +102,8 @@ class Query {
         // initially relax all source stops and add the newly improved stops by relaxation to the marked stops
         initialize();
 
-        if (config.isDoInitialTransferRelaxation()) {
-            footpathRelaxer.relaxInitial();
-            removeSuboptimalLabelsForRound(0);
-        }
+        footpathRelaxer.relaxInitial();
+        removeSuboptimalLabelsForRound(0);
 
         // if range is 0 or smaller there is no range, and we don't need to rerun rounds with different start offsets
         if (raptorRange <= 0) {
@@ -173,16 +171,6 @@ class Query {
 
             // scan all routs and mark stops that have improved
             routeScanner.scan(queryState.getRound());
-
-            // this is a special case where no initial transfer relaxation was done, to ensure that transfers from
-            // source stops are still accounted for these are manually marked in round 1 (after route scanning for
-            // performance reasons)
-            if( !config.isDoInitialTransferRelaxation() && queryState.getRound() == 1 ){
-                // mark all source stops for transfer relaxation after round 1
-                for (int sourceStopIndex : sourceStopIndices) {
-                    queryState.mark(sourceStopIndex);
-                }
-            }
 
             // relax footpaths for all newly marked stops
             footpathRelaxer.relax(queryState.getRound());

--- a/src/main/java/ch/naviqore/service/gtfs/raptor/routing/ConnectionGeoToGeo.java
+++ b/src/main/java/ch/naviqore/service/gtfs/raptor/routing/ConnectionGeoToGeo.java
@@ -29,7 +29,7 @@ class ConnectionGeoToGeo extends ConnectionQueryTemplate<GeoCoordinate, GeoCoord
      */
     ConnectionGeoToGeo(LocalDateTime time, TimeType timeType, ConnectionQueryConfig queryConfig,
                        RoutingQueryUtils utils, GeoCoordinate source, GeoCoordinate target) {
-        super(time, timeType, queryConfig, utils, source, target);
+        super(time, timeType, queryConfig, utils, source, target, false, false);
         sourceStop = null;
         targetStop = null;
     }
@@ -39,7 +39,7 @@ class ConnectionGeoToGeo extends ConnectionQueryTemplate<GeoCoordinate, GeoCoord
      */
     ConnectionGeoToGeo(LocalDateTime time, TimeType timeType, ConnectionQueryConfig queryConfig,
                        RoutingQueryUtils utils, Stop source, GeoCoordinate target) {
-        super(time, timeType, queryConfig, utils, source.getCoordinate(), target);
+        super(time, timeType, queryConfig, utils, source.getCoordinate(), target, false, false);
         sourceStop = source;
         targetStop = null;
     }
@@ -49,7 +49,7 @@ class ConnectionGeoToGeo extends ConnectionQueryTemplate<GeoCoordinate, GeoCoord
      */
     ConnectionGeoToGeo(LocalDateTime time, TimeType timeType, ConnectionQueryConfig queryConfig,
                        RoutingQueryUtils utils, GeoCoordinate source, Stop target) {
-        super(time, timeType, queryConfig, utils, source, target.getCoordinate());
+        super(time, timeType, queryConfig, utils, source, target.getCoordinate(), false, false);
         sourceStop = null;
         targetStop = target;
     }
@@ -59,7 +59,7 @@ class ConnectionGeoToGeo extends ConnectionQueryTemplate<GeoCoordinate, GeoCoord
      */
     ConnectionGeoToGeo(LocalDateTime time, TimeType timeType, ConnectionQueryConfig queryConfig,
                        RoutingQueryUtils utils, Stop source, Stop target) {
-        super(time, timeType, queryConfig, utils, source.getCoordinate(), target.getCoordinate());
+        super(time, timeType, queryConfig, utils, source.getCoordinate(), target.getCoordinate(), false, false);
         sourceStop = source;
         targetStop = target;
     }

--- a/src/main/java/ch/naviqore/service/gtfs/raptor/routing/ConnectionGeoToStop.java
+++ b/src/main/java/ch/naviqore/service/gtfs/raptor/routing/ConnectionGeoToStop.java
@@ -20,7 +20,7 @@ class ConnectionGeoToStop extends ConnectionQueryTemplate<GeoCoordinate, Stop> {
 
     ConnectionGeoToStop(LocalDateTime time, TimeType timeType, ConnectionQueryConfig queryConfig,
                         RoutingQueryUtils utils, GeoCoordinate source, Stop target) {
-        super(time, timeType, queryConfig, utils, source, target);
+        super(time, timeType, queryConfig, utils, source, target, false, true);
     }
 
     @Override

--- a/src/main/java/ch/naviqore/service/gtfs/raptor/routing/ConnectionQueryTemplate.java
+++ b/src/main/java/ch/naviqore/service/gtfs/raptor/routing/ConnectionQueryTemplate.java
@@ -32,6 +32,9 @@ abstract class ConnectionQueryTemplate<S, T> {
     private final S source;
     private final T target;
 
+    private final boolean allowSourceTransfers;
+    private final boolean allowTargetTransfers;
+
     protected abstract Map<String, LocalDateTime> prepareSourceStops(S source);
 
     protected abstract Map<String, Integer> prepareTargetStops(T target);
@@ -78,7 +81,8 @@ abstract class ConnectionQueryTemplate<S, T> {
         // query connection from raptor
         List<ch.naviqore.raptor.Connection> connections;
         try {
-            connections = utils.routeConnections(sourceStops, targetStops, timeType, queryConfig);
+            connections = utils.routeConnections(sourceStops, targetStops, timeType, queryConfig, allowSourceTransfers,
+                    allowTargetTransfers);
         } catch (RaptorAlgorithm.InvalidStopException e) {
             log.debug("{}: {}", e.getClass().getSimpleName(), e.getMessage());
             return handleInvalidStopException(e, source, target);

--- a/src/main/java/ch/naviqore/service/gtfs/raptor/routing/ConnectionStopToGeo.java
+++ b/src/main/java/ch/naviqore/service/gtfs/raptor/routing/ConnectionStopToGeo.java
@@ -17,7 +17,7 @@ class ConnectionStopToGeo extends ConnectionQueryTemplate<Stop, GeoCoordinate> {
 
     ConnectionStopToGeo(LocalDateTime time, TimeType timeType, ConnectionQueryConfig queryConfig,
                         RoutingQueryUtils utils, Stop source, GeoCoordinate target) {
-        super(time, timeType, queryConfig, utils, source, target);
+        super(time, timeType, queryConfig, utils, source, target, true, false);
     }
 
     @Override

--- a/src/main/java/ch/naviqore/service/gtfs/raptor/routing/ConnectionStopToStop.java
+++ b/src/main/java/ch/naviqore/service/gtfs/raptor/routing/ConnectionStopToStop.java
@@ -18,7 +18,7 @@ class ConnectionStopToStop extends ConnectionQueryTemplate<Stop, Stop> {
 
     ConnectionStopToStop(LocalDateTime time, TimeType timeType, ConnectionQueryConfig queryConfig,
                          RoutingQueryUtils utils, Stop source, Stop target) {
-        super(time, timeType, queryConfig, utils, source, target);
+        super(time, timeType, queryConfig, utils, source, target, true, true);
     }
 
     @Override

--- a/src/main/java/ch/naviqore/service/gtfs/raptor/routing/IsolineGeoSource.java
+++ b/src/main/java/ch/naviqore/service/gtfs/raptor/routing/IsolineGeoSource.java
@@ -18,7 +18,7 @@ class IsolineGeoSource extends IsolineQueryTemplate<GeoCoordinate> {
 
     IsolineGeoSource(LocalDateTime time, TimeType timeType, ConnectionQueryConfig queryConfig, RoutingQueryUtils utils,
                      GeoCoordinate source) {
-        super(time, timeType, queryConfig, utils, source);
+        super(time, timeType, queryConfig, utils, source, false);
     }
 
     @Override

--- a/src/main/java/ch/naviqore/service/gtfs/raptor/routing/IsolineQueryTemplate.java
+++ b/src/main/java/ch/naviqore/service/gtfs/raptor/routing/IsolineQueryTemplate.java
@@ -30,6 +30,8 @@ abstract class IsolineQueryTemplate<T> {
 
     private final T source;
 
+    private final boolean allowSourceTransfers;
+
     protected abstract Map<String, LocalDateTime> prepareSourceStops(T source);
 
     protected abstract Map<Stop, Connection> handleInvalidStopException(RaptorAlgorithm.InvalidStopException exception,
@@ -50,7 +52,7 @@ abstract class IsolineQueryTemplate<T> {
         // query isolines from raptor
         Map<String, ch.naviqore.raptor.Connection> isolines;
         try {
-            isolines = utils.createIsolines(sourceStops, timeType, queryConfig);
+            isolines = utils.createIsolines(sourceStops, timeType, queryConfig, allowSourceTransfers);
         } catch (RaptorAlgorithm.InvalidStopException e) {
             log.debug("{}: {}", e.getClass().getSimpleName(), e.getMessage());
             return handleInvalidStopException(e, source);

--- a/src/main/java/ch/naviqore/service/gtfs/raptor/routing/IsolineStopSource.java
+++ b/src/main/java/ch/naviqore/service/gtfs/raptor/routing/IsolineStopSource.java
@@ -17,7 +17,7 @@ class IsolineStopSource extends IsolineQueryTemplate<Stop> {
 
     IsolineStopSource(LocalDateTime time, TimeType timeType, ConnectionQueryConfig queryConfig, RoutingQueryUtils utils,
                       Stop source) {
-        super(time, timeType, queryConfig, utils, source);
+        super(time, timeType, queryConfig, utils, source, true);
     }
 
     @Override

--- a/src/main/java/ch/naviqore/service/gtfs/raptor/routing/RoutingQueryUtils.java
+++ b/src/main/java/ch/naviqore/service/gtfs/raptor/routing/RoutingQueryUtils.java
@@ -63,9 +63,6 @@ class RoutingQueryUtils {
                                                   boolean allowTargetTransfer) {
         QueryConfig config = TypeMapper.map(queryConfig);
         // TODO: discuss whether this should be modifiable
-        // we don't want consecutive transfers in connections
-        config.setAllowConsecutiveTransfers(false);
-        // TODO: discuss whether this should be modifiable
         // we don't want two one leg results if connection can be achieved with initial transfer (Round 0) and a one leg
         // connection (that is faster) --> Round 1
         config.setDoInitialTransferRelaxation(false);

--- a/src/main/java/ch/naviqore/service/gtfs/raptor/routing/RoutingQueryUtils.java
+++ b/src/main/java/ch/naviqore/service/gtfs/raptor/routing/RoutingQueryUtils.java
@@ -54,7 +54,7 @@ class RoutingQueryUtils {
     Map<String, ch.naviqore.raptor.Connection> createIsolines(Map<String, LocalDateTime> sourceStops, TimeType timeType,
                                                               ConnectionQueryConfig queryConfig,
                                                               boolean allowSourceTransfer) {
-        // TODO: discuss whether allowTargetTransfers  should be modifiable
+        // allow target transfers does not work for isolines since no targets are defined
         return raptor.routeIsolines(sourceStops, TypeMapper.map(timeType),
                 prepareQueryConfig(queryConfig, allowSourceTransfer, true));
     }
@@ -62,10 +62,6 @@ class RoutingQueryUtils {
     private static QueryConfig prepareQueryConfig(ConnectionQueryConfig queryConfig, boolean allowSourceTransfer,
                                                   boolean allowTargetTransfer) {
         QueryConfig config = TypeMapper.map(queryConfig);
-        // TODO: discuss whether this should be modifiable
-        // we don't want two one leg results if connection can be achieved with initial transfer (Round 0) and a one leg
-        // connection (that is faster) --> Round 1
-        config.setDoInitialTransferRelaxation(false);
         config.setAllowSourceTransfer(allowSourceTransfer);
         config.setAllowTargetTransfer(allowTargetTransfer);
 

--- a/src/main/java/ch/naviqore/service/gtfs/raptor/routing/RoutingQueryUtils.java
+++ b/src/main/java/ch/naviqore/service/gtfs/raptor/routing/RoutingQueryUtils.java
@@ -38,6 +38,15 @@ class RoutingQueryUtils {
     private final WalkCalculator walkCalculator;
     private final RaptorAlgorithm raptor;
 
+    private static QueryConfig prepareQueryConfig(ConnectionQueryConfig queryConfig, boolean allowSourceTransfer,
+                                                  boolean allowTargetTransfer) {
+        QueryConfig config = TypeMapper.map(queryConfig);
+        config.setAllowSourceTransfer(allowSourceTransfer);
+        config.setAllowTargetTransfer(allowTargetTransfer);
+
+        return config;
+    }
+
     List<ch.naviqore.raptor.Connection> routeConnections(Map<String, LocalDateTime> sourceStops,
                                                          Map<String, Integer> targetStops, TimeType timeType,
                                                          ConnectionQueryConfig queryConfig, boolean allowSourceTransfer,
@@ -57,15 +66,6 @@ class RoutingQueryUtils {
         // allow target transfers does not work for isolines since no targets are defined
         return raptor.routeIsolines(sourceStops, TypeMapper.map(timeType),
                 prepareQueryConfig(queryConfig, allowSourceTransfer, true));
-    }
-
-    private static QueryConfig prepareQueryConfig(ConnectionQueryConfig queryConfig, boolean allowSourceTransfer,
-                                                  boolean allowTargetTransfer) {
-        QueryConfig config = TypeMapper.map(queryConfig);
-        config.setAllowSourceTransfer(allowSourceTransfer);
-        config.setAllowTargetTransfer(allowTargetTransfer);
-
-        return config;
     }
 
     Map<String, LocalDateTime> getStopsWithWalkTimeFromLocation(GeoCoordinate location, LocalDateTime startTime,

--- a/src/main/java/ch/naviqore/service/gtfs/raptor/routing/RoutingQueryUtils.java
+++ b/src/main/java/ch/naviqore/service/gtfs/raptor/routing/RoutingQueryUtils.java
@@ -38,8 +38,8 @@ class RoutingQueryUtils {
     private final WalkCalculator walkCalculator;
     private final RaptorAlgorithm raptor;
 
-    private static QueryConfig prepareQueryConfig(ConnectionQueryConfig queryConfig, boolean allowSourceTransfer,
-                                                  boolean allowTargetTransfer) {
+    private static QueryConfig prepareRaptorQueryConfig(ConnectionQueryConfig queryConfig, boolean allowSourceTransfer,
+                                                        boolean allowTargetTransfer) {
         QueryConfig config = TypeMapper.map(queryConfig);
         config.setAllowSourceTransfer(allowSourceTransfer);
         config.setAllowTargetTransfer(allowTargetTransfer);
@@ -51,7 +51,7 @@ class RoutingQueryUtils {
                                                          Map<String, Integer> targetStops, TimeType timeType,
                                                          ConnectionQueryConfig queryConfig, boolean allowSourceTransfer,
                                                          boolean allowTargetTransfer) {
-        QueryConfig config = prepareQueryConfig(queryConfig, allowSourceTransfer, allowTargetTransfer);
+        QueryConfig config = prepareRaptorQueryConfig(queryConfig, allowSourceTransfer, allowTargetTransfer);
 
         if (timeType == TimeType.DEPARTURE) {
             return raptor.routeEarliestArrival(sourceStops, targetStops, config);
@@ -65,7 +65,7 @@ class RoutingQueryUtils {
                                                               boolean allowSourceTransfer) {
         // allow target transfers does not work for isolines since no targets are defined
         return raptor.routeIsolines(sourceStops, TypeMapper.map(timeType),
-                prepareQueryConfig(queryConfig, allowSourceTransfer, true));
+                prepareRaptorQueryConfig(queryConfig, allowSourceTransfer, true));
     }
 
     Map<String, LocalDateTime> getStopsWithWalkTimeFromLocation(GeoCoordinate location, LocalDateTime startTime,

--- a/src/test/java/ch/naviqore/raptor/router/RaptorTransferBehaviorTest.java
+++ b/src/test/java/ch/naviqore/raptor/router/RaptorTransferBehaviorTest.java
@@ -1,0 +1,95 @@
+package ch.naviqore.raptor.router;
+
+import ch.naviqore.raptor.Connection;
+import ch.naviqore.raptor.QueryConfig;
+import ch.naviqore.raptor.RaptorAlgorithm;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class to test all transfer handling rules in the QueryConfig
+ */
+@ExtendWith(RaptorRouterTestExtension.class)
+public class RaptorTransferBehaviorTest {
+
+    private static final int DAY_START_HOUR = 8;
+    private static final int DAY_END_HOUR = 9;
+
+    @Nested
+    class InitialTransferRelaxation {
+        @Test
+        void connectBetweenStops_withInitialFootpathRelaxation(RaptorRouterTestBuilder builder) {
+            RaptorAlgorithm router = TransferBehaviorHelpers.prepareRouter(builder, 5, 30);
+            QueryConfig config = new QueryConfig();
+            config.setDoInitialTransferRelaxation(true);
+
+            List<Connection> connections = TransferBehaviorHelpers.routeBetweenStops(router, "A", "B", config);
+
+            // Because initial transfer relaxation is one, this will return two solutions.
+            // Round 0 best time with transfer between A-B with one transfer leg
+            // Round 1 best time (faster) with route 1 from A to B with one route leg (no transfers)
+            assertEquals(2, connections.size());
+            Connection walkConnection = connections.getFirst();
+            assertEquals(0, walkConnection.getRouteLegs().size());
+            assertEquals(1, walkConnection.getWalkTransfers().size());
+
+            Connection routeConnection = connections.getLast();
+            assertEquals(1, routeConnection.getRouteLegs().size());
+            assertEquals(0, routeConnection.getWalkTransfers().size());
+        }
+
+        @Test
+        void connectBetweenStops_withoutInitialFootpathRelaxation(RaptorRouterTestBuilder builder) {
+            RaptorAlgorithm router = TransferBehaviorHelpers.prepareRouter(builder, 5, 30);
+            QueryConfig config = new QueryConfig();
+            config.setDoInitialTransferRelaxation(false);
+
+            List<Connection> connections = TransferBehaviorHelpers.routeBetweenStops(router, "A", "B", config);
+
+            // Because nothing should happen in round 0 (no initial transfer relaxation) only one "one leg" connection
+            // should be returned and since the route leg will be faster, this should be the only solution
+            assertEquals(1, connections.size());
+            Connection connection = connections.getFirst();
+            assertEquals(1, connection.getRouteLegs().size());
+            assertEquals(0, connection.getWalkTransfers().size());
+        }
+    }
+
+    static class TransferBehaviorHelpers {
+        /**
+         * Tests will only use a simplified version of a raptor schedule. Focus will lie on the stop sequence A - B - C,
+         * which are connected by route 1 (A-G) and have transfers between each-other. Therefore, allowing completing
+         * trips between all stops depending on the query configuration.
+         */
+        static RaptorAlgorithm prepareRouter(RaptorRouterTestBuilder builder, int routeTimeBetweenStops,
+                                             int transferTimeBetweenStops) {
+            builder.withAddRoute1_AG(0, 15, routeTimeBetweenStops, 0);
+            builder.withAddTransfer("A", "B", transferTimeBetweenStops);
+            builder.withAddTransfer("B", "C", transferTimeBetweenStops);
+            builder.withMaxDaysToScan(1);
+            return builder.build(DAY_START_HOUR, DAY_END_HOUR);
+        }
+
+        static List<Connection> routeBetweenStops(RaptorAlgorithm router, QueryConfig config) {
+            return routeBetweenStops(router, "A", "C", config);
+        }
+
+        static List<Connection> routeBetweenStops(RaptorAlgorithm router, String stop1, String stop2,
+                                                  QueryConfig config) {
+            LocalDateTime startTime = LocalDateTime.of(2000, 1, 1, DAY_START_HOUR, 0);
+            return routeBetweenStops(router, stop1, stop2, startTime, config);
+        }
+
+        static List<Connection> routeBetweenStops(RaptorAlgorithm router, String stop1, String stop2,
+                                                  LocalDateTime startTime, QueryConfig config) {
+            return RaptorRouterTestHelpers.routeEarliestArrival(router, stop1, stop2, startTime, config);
+        }
+    }
+
+}

--- a/src/test/java/ch/naviqore/raptor/router/RaptorTransferBehaviorTest.java
+++ b/src/test/java/ch/naviqore/raptor/router/RaptorTransferBehaviorTest.java
@@ -59,6 +59,25 @@ public class RaptorTransferBehaviorTest {
             assertEquals(1, connection.getRouteLegs().size());
             assertEquals(0, connection.getWalkTransfers().size());
         }
+
+        @Test
+        void connectBetweenStops_withoutInitialFootpathRelaxationOnlyByTransfer(RaptorRouterTestBuilder builder) {
+            RaptorAlgorithm router = TransferBehaviorHelpers.prepareRouter(builder, 5, 30);
+            QueryConfig config = new QueryConfig();
+            config.setDoInitialTransferRelaxation(false);
+
+            // ensure that no routes are active anymore
+            LocalDateTime startTime = LocalDateTime.of(2000, 1, 1, DAY_END_HOUR + 1, 0);
+
+            List<Connection> connections = TransferBehaviorHelpers.routeBetweenStops(router, "A", "B", startTime, config);
+
+            // even though initial transfer relaxation is turned off, in round 1 transfer relaxation should be performed
+            // from source stops (after no faster route trips were found!).
+            assertEquals(1, connections.size());
+            Connection connection = connections.getFirst();
+            assertEquals(0, connection.getRouteLegs().size());
+            assertEquals(1, connection.getWalkTransfers().size());
+        }
     }
 
     static class TransferBehaviorHelpers {

--- a/src/test/java/ch/naviqore/raptor/router/RaptorTransferBehaviorTest.java
+++ b/src/test/java/ch/naviqore/raptor/router/RaptorTransferBehaviorTest.java
@@ -23,66 +23,6 @@ public class RaptorTransferBehaviorTest {
     private static final int DAY_END_HOUR = 9;
 
     @Nested
-    class InitialTransferRelaxation {
-        @Test
-        void connectBetweenStops_withInitialFootpathRelaxation(RaptorRouterTestBuilder builder) {
-            RaptorAlgorithm router = TransferBehaviorHelpers.prepareRouter(builder, 5, 30);
-            QueryConfig config = new QueryConfig();
-            config.setDoInitialTransferRelaxation(true);
-
-            List<Connection> connections = TransferBehaviorHelpers.routeBetweenStops(router, "A", "B", config);
-
-            // Because initial transfer relaxation is one, this will return two solutions.
-            // Round 0 best time with transfer between A-B with one transfer leg
-            // Round 1 best time (faster) with route 1 from A to B with one route leg (no transfers)
-            assertEquals(2, connections.size());
-            Connection walkConnection = connections.getFirst();
-            assertEquals(0, walkConnection.getRouteLegs().size());
-            assertEquals(1, walkConnection.getWalkTransfers().size());
-
-            Connection routeConnection = connections.getLast();
-            assertEquals(1, routeConnection.getRouteLegs().size());
-            assertEquals(0, routeConnection.getWalkTransfers().size());
-        }
-
-        @Test
-        void connectBetweenStops_withoutInitialFootpathRelaxation(RaptorRouterTestBuilder builder) {
-            RaptorAlgorithm router = TransferBehaviorHelpers.prepareRouter(builder, 5, 30);
-            QueryConfig config = new QueryConfig();
-            config.setDoInitialTransferRelaxation(false);
-
-            List<Connection> connections = TransferBehaviorHelpers.routeBetweenStops(router, "A", "B", config);
-
-            // Because nothing should happen in round 0 (no initial transfer relaxation) only one "one leg" connection
-            // should be returned and since the route leg will be faster, this should be the only solution
-            assertEquals(1, connections.size());
-            Connection connection = connections.getFirst();
-            assertEquals(1, connection.getRouteLegs().size());
-            assertEquals(0, connection.getWalkTransfers().size());
-        }
-
-        @Test
-        void connectBetweenStops_withoutInitialFootpathRelaxationOnlyByTransfer(RaptorRouterTestBuilder builder) {
-            RaptorAlgorithm router = TransferBehaviorHelpers.prepareRouter(builder, 5, 30);
-            QueryConfig config = new QueryConfig();
-            config.setDoInitialTransferRelaxation(false);
-
-            // ensure that no routes are active anymore
-            LocalDateTime startTime = LocalDateTime.of(2000, 1, 1, DAY_END_HOUR + 1, 0);
-
-            List<Connection> connections = TransferBehaviorHelpers.routeBetweenStops(router, "A", "B", startTime,
-                    config);
-
-            // even though initial transfer relaxation is turned off, in round 1 transfer relaxation should be performed
-            // from source stops (after no faster route trips were found!).
-            assertEquals(1, connections.size());
-            Connection connection = connections.getFirst();
-            assertEquals(0, connection.getRouteLegs().size());
-            assertEquals(1, connection.getWalkTransfers().size());
-        }
-    }
-
-    @Nested
     class SourceTransferRelaxation {
 
         @Test

--- a/src/test/java/ch/naviqore/service/gtfs/raptor/GtfsRaptorTestSchedule.java
+++ b/src/test/java/ch/naviqore/service/gtfs/raptor/GtfsRaptorTestSchedule.java
@@ -14,18 +14,18 @@ import java.util.EnumSet;
 /**
  * GTFS schedule builder for testing. Builds a schedule as below
  * <pre>
- *     |--------B1------------C1
+ *     |--------B1------------C1-----------D1
  *     |
- * A---|       (B)      |-----C           (D)
- *     |                |
- *     |--------B2 -----|    (C2)
+ * A---|       (B)      |-----C-------|   (D)           (E)
+ *     |                |             |
+ *     |--------B2 -----|    (C2)     |----D2
  * </pre>
  * <ul>
- *     <li><b>Route 1</b>: Passes through A - B1 - C1</li>
- *     <li><b>Route 2</b>: Passes through A - B2 - C</li>
+ *     <li><b>Route 1</b>: Passes through A - B1 - C1 - D1</li>
+ *     <li><b>Route 2</b>: Passes through A - B2 - C  - D2</li>
  * </ul>
- * Stops B, C2 and D have no departures/arrivals and should not be included in the raptor conversion.
- * Stops B and C are parents of stops B1, B2 and C1, C2, respectively.
+ * Stops B, C2, D, E have no departures/arrivals and should not be included in the raptor conversion.
+ * Stops B, C, D are parents of stops (B1, B2), (C1, C2) and (D1, D2) respectively.
  */
 public class GtfsRaptorTestSchedule {
 
@@ -47,13 +47,17 @@ public class GtfsRaptorTestSchedule {
         builder.addStop("C1", "C1", 0.001, 2.0, "C", AccessibilityInformation.UNKNOWN);
         builder.addStop("C2", "C2", -0.001, 2.0, "C", AccessibilityInformation.UNKNOWN);
         builder.addStop("D", "D", 0.0, 3.0);
+        builder.addStop("D1", "D1", 0.001, 3.0, "D", AccessibilityInformation.UNKNOWN);
+        builder.addStop("D2", "D2", -0.001, 3.0, "D", AccessibilityInformation.UNKNOWN);
+        builder.addStop("E", "E", 0.0, 4.0);
 
-        // Route 1 goes from A, B1, C1
+        // Route 1 goes from A, B1, C1, D2
         builder.addRoute("R1", "agency", "R1", "R1", RouteType.parse(1));
         builder.addTrip("T1", "R1", "always", "C1");
         builder.addStopTime("T1", "A", new ServiceDayTime(60), new ServiceDayTime(120));
         builder.addStopTime("T1", "B1", new ServiceDayTime(180), new ServiceDayTime(240));
         builder.addStopTime("T1", "C1", new ServiceDayTime(301), new ServiceDayTime(360));
+        builder.addStopTime("T1", "D1", new ServiceDayTime(420), new ServiceDayTime(480));
 
         // Route 2 goes from A, B2, C
         builder.addRoute("R2", "agency", "R2", "R2", RouteType.parse(1));
@@ -61,6 +65,7 @@ public class GtfsRaptorTestSchedule {
         builder.addStopTime("T2", "A", new ServiceDayTime(60), new ServiceDayTime(120));
         builder.addStopTime("T2", "B2", new ServiceDayTime(180), new ServiceDayTime(240));
         builder.addStopTime("T2", "C", new ServiceDayTime(300), new ServiceDayTime(360));
+        builder.addStopTime("T2", "D2", new ServiceDayTime(420), new ServiceDayTime(480));
     }
 
     public void addTransfer(String fromStopId, String toStopId, TransferType type, int duration) {

--- a/src/test/java/ch/naviqore/service/gtfs/raptor/GtfsRaptorTestSchedule.java
+++ b/src/test/java/ch/naviqore/service/gtfs/raptor/GtfsRaptorTestSchedule.java
@@ -46,14 +46,15 @@ public class GtfsRaptorTestSchedule {
         builder.addStop("C", "C", 0.0, 2.0);
         builder.addStop("C1", "C1", 0.001, 2.0, "C", AccessibilityInformation.UNKNOWN);
         builder.addStop("C2", "C2", -0.001, 2.0, "C", AccessibilityInformation.UNKNOWN);
+        // D, D1 and D2 are more than 500 m apart!
         builder.addStop("D", "D", 0.0, 3.0);
-        builder.addStop("D1", "D1", 0.001, 3.0, "D", AccessibilityInformation.UNKNOWN);
-        builder.addStop("D2", "D2", -0.001, 3.0, "D", AccessibilityInformation.UNKNOWN);
+        builder.addStop("D1", "D1", 0.005, 3.0, "D", AccessibilityInformation.UNKNOWN);
+        builder.addStop("D2", "D2", -0.005, 3.0, "D", AccessibilityInformation.UNKNOWN);
         builder.addStop("E", "E", 0.0, 4.0);
 
         // Route 1 goes from A, B1, C1, D2
         builder.addRoute("R1", "agency", "R1", "R1", RouteType.parse(1));
-        builder.addTrip("T1", "R1", "always", "C1");
+        builder.addTrip("T1", "R1", "always", "D1");
         builder.addStopTime("T1", "A", new ServiceDayTime(60), new ServiceDayTime(120));
         builder.addStopTime("T1", "B1", new ServiceDayTime(180), new ServiceDayTime(240));
         builder.addStopTime("T1", "C1", new ServiceDayTime(301), new ServiceDayTime(360));
@@ -61,7 +62,7 @@ public class GtfsRaptorTestSchedule {
 
         // Route 2 goes from A, B2, C
         builder.addRoute("R2", "agency", "R2", "R2", RouteType.parse(1));
-        builder.addTrip("T2", "R2", "always", "C");
+        builder.addTrip("T2", "R2", "always", "D2");
         builder.addStopTime("T2", "A", new ServiceDayTime(60), new ServiceDayTime(120));
         builder.addStopTime("T2", "B2", new ServiceDayTime(180), new ServiceDayTime(240));
         builder.addStopTime("T2", "C", new ServiceDayTime(300), new ServiceDayTime(360));

--- a/src/test/java/ch/naviqore/service/gtfs/raptor/routing/RoutingQueryFacadeIT.java
+++ b/src/test/java/ch/naviqore/service/gtfs/raptor/routing/RoutingQueryFacadeIT.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import static ch.naviqore.service.config.ServiceConfig.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RoutingQueryFacadeIT {
 
@@ -318,8 +317,8 @@ class RoutingQueryFacadeIT {
 
                 // when the original request to route to D2 fails, it will fall back to GeoToGeo coordinate routing,
                 // however since D1 and D2 are more than 500 m apart this will also fail.
-                connections = facade.queryConnections(startTime, TimeType.DEPARTURE, QUERY_CONFIG,
-                        sourceCoordinate, getStopById("D2"));
+                connections = facade.queryConnections(startTime, TimeType.DEPARTURE, QUERY_CONFIG, sourceCoordinate,
+                        getStopById("D2"));
                 assertThat(connections).hasSize(0);
             }
 

--- a/src/test/java/ch/naviqore/service/gtfs/raptor/routing/RoutingQueryFacadeIT.java
+++ b/src/test/java/ch/naviqore/service/gtfs/raptor/routing/RoutingQueryFacadeIT.java
@@ -320,7 +320,7 @@ class RoutingQueryFacadeIT {
                 @BeforeEach
                 void setUp() {
                     source = getStopById("A");
-                    target = getStopById("D");
+                    target = getStopById("E");
                 }
 
                 @Test
@@ -407,7 +407,7 @@ class RoutingQueryFacadeIT {
                 Map<Stop, ch.naviqore.service.Connection> isolines = facade.queryIsolines(DATE_TIME, TimeType.DEPARTURE,
                         QUERY_CONFIG, sourceStop);
 
-                assertThat(isolines).hasSize(4);
+                assertThat(isolines).hasSize(6);
 
                 for (Connection isoline : isolines.values()) {
                     assertThat(isoline.getLegs()).hasSize(1);
@@ -442,7 +442,7 @@ class RoutingQueryFacadeIT {
                 Map<Stop, ch.naviqore.service.Connection> isolines = facade.queryIsolines(DATE_TIME, TimeType.DEPARTURE,
                         QUERY_CONFIG, sourceCoordinate);
 
-                assertThat(isolines).hasSize(4);
+                assertThat(isolines).hasSize(6);
 
                 for (Connection isoline : isolines.values()) {
                     assertThat(isoline.getLegs()).hasSize(2);
@@ -497,7 +497,7 @@ class RoutingQueryFacadeIT {
                 @Test
                 void arrival() throws ConnectionRoutingException {
                     Map<Stop, ch.naviqore.service.Connection> isolines = facade.queryIsolines(DATE_TIME,
-                            TimeType.ARRIVAL, QUERY_CONFIG, getStopById("D"));
+                            TimeType.ARRIVAL, QUERY_CONFIG, getStopById("E"));
 
                     assertThat(isolines).isEmpty();
                 }
@@ -510,9 +510,9 @@ class RoutingQueryFacadeIT {
                 @Test
                 void departure() throws ConnectionRoutingException {
                     Map<Stop, ch.naviqore.service.Connection> isolines = facade.queryIsolines(DATE_TIME,
-                            TimeType.DEPARTURE, QUERY_CONFIG, getStopById("C2"));
+                            TimeType.DEPARTURE, QUERY_CONFIG, getStopById("D"));
 
-                    // Expected behavior: Since no departures from stops C, C1 and C2, the result must be empty.
+                    // Expected behavior: Since no departures from stops D, D1 and D2, the result must be empty.
                     assertThat(isolines).isEmpty();
                 }
 


### PR DESCRIPTION
Hi,

To solve the issue of having potential consecutive walks when routing from a geo coordinate (e.g. walk to source stop (from service), followed by initial transfer between stops from the raptor router), I've added more QueryConfiguration options for the raptor module. Allowing to prevent transfers from source stops and transfers to target stops). I think this is the most elegant way of ensuring that any max walking time query configuration values are not violated.

In the process I was thinking about adding more optional configurations to the RAPTOR module. None of those are necessary, but might be nice to haves.

- Currently only public transit legs count towards rounds. Resulting in behavior that you might get two connections with one leg as a result (-> a slower walk from A-B (round 0) and a faster direct public transit connection from A-B (round 1). Although this response isn't bad. I've seen that the KIT implementation, has a configuration parameter to specify whether transfers should be applied in a separate round, which could maybe be an interesting extension.
- Also our algorithm currently doesn't allow chaining transfers to reach a destination. Probably also not the ultimate goal of a routing request but theoretically could be implemented to allow routing very edge case requests.

Last idea only service related (not raptor):
- In the QueryConfig we currently specify max walking time as a possible parameter. When routing from GeoCoordinates we look for stops within the proximity of 500 m (this value is configurable on the service level). However I think it would be better if we calculate or query stops using a search radius based on the query max allowed walking distance. (capping it with a reasonable max value when no max walking duration is specified).